### PR TITLE
Synchronize theming and wire up interaction audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       --bg-alt: #ffffff;
       --text-primary: #1449ff;
       --topo-light: #ffffff;
-      --theme-transition: 0.45s;
+      --theme-transition: 1s;
     }
 
     body.dark-mode {
@@ -54,6 +54,65 @@
 
     .i18n-loading [data-i18n] {
       visibility: hidden;
+    }
+
+    #audio-debug-panel {
+      position: fixed;
+      top: 12px;
+      left: 12px;
+      padding: 10px 12px;
+      background: rgba(0, 0, 0, 0.65);
+      color: #ffffff;
+      font-family: 'Outfit', sans-serif;
+      font-size: 12px;
+      line-height: 1.4;
+      border-radius: 8px;
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      z-index: 1000;
+      pointer-events: none;
+      min-width: 180px;
+      white-space: pre-line;
+      transition: background-color var(--theme-transition) ease, color var(--theme-transition) ease, border-color var(--theme-transition) ease;
+    }
+
+    body.dark-mode #audio-debug-panel {
+      background: rgba(13, 15, 20, 0.78);
+      border-color: rgba(215, 43, 43, 0.45);
+      color: #f4f4f4;
+    }
+
+    #audio-debug-panel strong {
+      display: block;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      margin-bottom: 4px;
+      text-transform: uppercase;
+    }
+
+    #audio-debug-panel ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    #audio-debug-panel li {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 16px;
+      font-family: 'Ferrite Display', sans-serif;
+      font-size: 11px;
+      letter-spacing: 0.08em;
+    }
+
+    #audio-debug-panel .audio-debug-empty {
+      opacity: 0.7;
+      font-style: italic;
+      font-family: 'Outfit', sans-serif;
+      letter-spacing: 0.04em;
     }
 
     /* Language toggle button styling */
@@ -471,19 +530,42 @@
       justify-content: center;
       height: 100%;
       border: 4px solid var(--accent);
-      background: transparent;
+      background: var(--bg-alt);
       cursor: pointer;
       flex: 0 0 auto;
       border-radius: 0;
-      min-width: clamp(160px, 22vw, 420px);
+      min-width: 0;
       overflow: hidden;
+      transition: border-color var(--theme-transition) ease, background-color var(--theme-transition) ease;
     }
 
     .feature-gallery-item img {
       height: 100%;
       width: 100%;
       display: block;
-      object-fit: cover;
+      object-fit: contain;
+    }
+
+    .feature-gallery-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      padding: 0 clamp(20px, 6vw, 48px);
+      border: 4px solid var(--accent);
+      color: var(--accent);
+      background: var(--bg-alt);
+      text-decoration: none;
+      font-family: 'Ferrite Display', sans-serif;
+      font-size: clamp(18px, 2.2vw, 34px);
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      white-space: nowrap;
+      transition: border-color var(--theme-transition) ease, color var(--theme-transition) ease, background-color var(--theme-transition) ease;
+    }
+
+    .feature-gallery.links-mode .feature-gallery-track {
+      gap: clamp(28px, 5vw, 72px);
     }
 
     .feature-link-placeholder {
@@ -522,7 +604,7 @@
       letter-spacing: 0.12em;
       text-transform: uppercase;
       font-family: 'Ferrite Display', sans-serif;
-      transition: color 0.25s ease;
+      transition: color var(--theme-transition) ease;
       white-space: nowrap;
     }
 
@@ -816,12 +898,6 @@ document.addEventListener('DOMContentLoaded', () => {
   let galleryOffset = 0;
   let galleryLastTs = 0;
   const GALLERY_SPEED = 40; // pixels per second
-  let linkAnimationId = null;
-  let linkTrackEl = null;
-  let linkLoopWidth = 0;
-  let linkOffset = 0;
-  let linkLastTs = 0;
-
   const DIRECT_VIDEO_EXT = /\.(mp4|webm|ogg)(?:\?.*)?$/i;
 
   const SOUND_FILES = {
@@ -851,7 +927,9 @@ document.addEventListener('DOMContentLoaded', () => {
         ensureLoop() { return Promise.resolve(null); },
         setLoopVolume() {},
         stopLoop() {},
-        isLoopActive() { return false; }
+        isLoopActive() { return false; },
+        getActiveSounds() { return []; },
+        onActiveChange() { return () => {}; }
       };
     }
 
@@ -865,6 +943,78 @@ document.addEventListener('DOMContentLoaded', () => {
     const loading = new Map();
     const loops = new Map();
     const cooldowns = new Map();
+    const activeSounds = new Map();
+    const debugListeners = new Set();
+    const scheduleTimeout = (typeof window !== 'undefined' && typeof window.setTimeout === 'function')
+      ? window.setTimeout.bind(window)
+      : setTimeout;
+
+    function snapshotActiveSounds() {
+      return Array.from(activeSounds.entries()).map(([name, info]) => ({
+        name,
+        loop: Boolean(info.loop),
+        fading: Boolean(info.fading),
+        count: Math.max(1, info.count || 1)
+      }));
+    }
+
+    function notifyActiveChange() {
+      const snapshot = snapshotActiveSounds();
+      debugListeners.forEach(listener => {
+        try {
+          listener(snapshot);
+        } catch (error) {
+          console.warn('[audio] monitor listener error', error);
+        }
+      });
+    }
+
+    function setActiveSound(name, data = {}) {
+      const isLoop = Boolean(data.loop);
+      const current = activeSounds.get(name);
+      const nextCount = isLoop ? 1 : Math.max(1, (current?.count || 0) + 1);
+      activeSounds.set(name, {
+        loop: isLoop,
+        fading: Boolean(data.fading),
+        count: nextCount
+      });
+      notifyActiveChange();
+    }
+
+    function markSoundFading(name, fadeSeconds = 0) {
+      const entry = activeSounds.get(name);
+      if (!entry) return;
+      if (fadeSeconds <= 0) {
+        activeSounds.delete(name);
+        notifyActiveChange();
+        return;
+      }
+      const next = { ...entry, fading: true };
+      activeSounds.set(name, next);
+      notifyActiveChange();
+      scheduleTimeout(() => {
+        if (activeSounds.get(name) === next) {
+          activeSounds.delete(name);
+          notifyActiveChange();
+        }
+      }, Math.max(fadeSeconds * 1000 + 120, 200));
+    }
+
+    function clearActiveSound(name) {
+      const entry = activeSounds.get(name);
+      if (!entry) return;
+      if (!entry.loop && entry.count > 1) {
+        activeSounds.set(name, {
+          loop: false,
+          fading: false,
+          count: entry.count - 1
+        });
+        notifyActiveChange();
+        return;
+      }
+      activeSounds.delete(name);
+      notifyActiveChange();
+    }
 
     const DEFAULT_FADE_IN = 1;
     const DEFAULT_FADE_OUT = 3;
@@ -935,6 +1085,8 @@ document.addEventListener('DOMContentLoaded', () => {
         source.connect(gain);
         gain.connect(master);
         source.start(now);
+        setActiveSound(name, { loop: false });
+        source.onended = () => clearActiveSound(name);
         const safeVolume = Math.max(0, volume);
         if (fadeIn > 0) {
           gain.gain.linearRampToValueAtTime(safeVolume, now + fadeIn);
@@ -957,6 +1109,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (typeof options.volume === 'number') {
           setLoopVolume(name, options.volume, options.ramp);
         }
+        setActiveSound(name, { loop: true, fading: false });
         return Promise.resolve(existing);
       }
 
@@ -986,8 +1139,10 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
           gain.gain.setValueAtTime(targetVol, now);
         }
+        source.onended = () => clearActiveSound(name);
         const entry = { source, gain, volumeTarget: targetVol };
         loops.set(name, entry);
+        setActiveSound(name, { loop: true, fading: false });
         return entry;
       }).catch(() => null);
     }
@@ -1014,6 +1169,7 @@ document.addEventListener('DOMContentLoaded', () => {
       entry.gain.gain.cancelScheduledValues(now);
       entry.gain.gain.setValueAtTime(entry.gain.gain.value, now);
       entry.gain.gain.linearRampToValueAtTime(0.0001, now + fadeDuration);
+      markSoundFading(name, fadeDuration);
       try {
         entry.source.stop(now + fadeDuration + 0.1);
       } catch (error) {
@@ -1032,12 +1188,82 @@ document.addEventListener('DOMContentLoaded', () => {
       ensureLoop,
       setLoopVolume,
       stopLoop,
-      isLoopActive
+      isLoopActive,
+      getActiveSounds: snapshotActiveSounds,
+      onActiveChange(callback) {
+        if (typeof callback !== 'function') {
+          return () => {};
+        }
+        debugListeners.add(callback);
+        try {
+          callback(snapshotActiveSounds());
+        } catch (error) {
+          console.warn('[audio] monitor listener error', error);
+        }
+        return () => {
+          debugListeners.delete(callback);
+        };
+      }
     };
   }
 
   const soundController = createSoundController();
   const audioSupported = Boolean(soundController && soundController.supported);
+  const audioDebugPanel = document.createElement('div');
+  audioDebugPanel.id = 'audio-debug-panel';
+  const audioDebugTitle = document.createElement('strong');
+  audioDebugTitle.textContent = 'Audio Monitor';
+  const audioDebugEmpty = document.createElement('div');
+  audioDebugEmpty.className = 'audio-debug-empty';
+  const audioDebugList = document.createElement('ul');
+  audioDebugPanel.append(audioDebugTitle, audioDebugEmpty, audioDebugList);
+  document.body.appendChild(audioDebugPanel);
+
+  function updateAudioDebugPanel(sounds = []) {
+    if (!audioSupported) {
+      audioDebugEmpty.textContent = 'Audio unavailable';
+      audioDebugEmpty.style.display = 'block';
+      audioDebugList.style.display = 'none';
+      audioDebugList.innerHTML = '';
+      return;
+    }
+    const entries = Array.isArray(sounds) ? sounds.slice().sort((a, b) => a.name.localeCompare(b.name)) : [];
+    if (!entries.length) {
+      audioDebugEmpty.textContent = 'No audio active';
+      audioDebugEmpty.style.display = 'block';
+      audioDebugList.style.display = 'none';
+      audioDebugList.innerHTML = '';
+      return;
+    }
+    audioDebugEmpty.style.display = 'none';
+    audioDebugList.style.display = 'flex';
+    audioDebugList.innerHTML = '';
+    entries.forEach(sound => {
+      const item = document.createElement('li');
+      const nameSpan = document.createElement('span');
+      nameSpan.textContent = sound.name;
+      const statusSpan = document.createElement('span');
+      let statusText = sound.loop ? 'looping' : 'one-shot';
+      if (!sound.loop && sound.count && sound.count > 1) {
+        statusText += ` ×${sound.count}`;
+      }
+      if (sound.fading) {
+        statusText += ' (fading)';
+      }
+      statusSpan.textContent = statusText;
+      item.append(nameSpan, statusSpan);
+      audioDebugList.appendChild(item);
+    });
+  }
+
+  const initialActive = typeof soundController.getActiveSounds === 'function'
+    ? soundController.getActiveSounds()
+    : [];
+  updateAudioDebugPanel(initialActive);
+  if (typeof soundController.onActiveChange === 'function') {
+    soundController.onActiveChange(updateAudioDebugPanel);
+  }
+
   let audioPrimed = false;
   let introPlayed = false;
   let folderZoneActive = false;
@@ -1387,6 +1613,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const naturalWidth = img.naturalWidth || 0;
     const naturalHeight = img.naturalHeight || 0;
     if (naturalWidth <= 0 || naturalHeight <= 0) {
+      item.style.removeProperty('aspect-ratio');
+      item.style.removeProperty('width');
       if (attempt < 2) {
         requestAnimationFrame(() => adjustGalleryItemSize(item, img, attempt + 1));
       }
@@ -1394,14 +1622,17 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const galleryHeight = getFeatureGalleryHeight();
     if (galleryHeight <= 0) {
+      item.style.removeProperty('aspect-ratio');
+      item.style.removeProperty('width');
       if (attempt < 2) {
         requestAnimationFrame(() => adjustGalleryItemSize(item, img, attempt + 1));
       }
       return;
     }
     const ratio = naturalWidth / naturalHeight;
-    const width = Math.max(galleryHeight * ratio, galleryHeight * 0.72);
+    const width = galleryHeight * ratio;
     item.style.width = `${width}px`;
+    item.style.aspectRatio = `${naturalWidth} / ${naturalHeight}`;
   }
 
   function resizeActiveGalleryItems() {
@@ -1418,7 +1649,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function clearFeatureGallery() {
     if (featureGallery) {
       featureGallery.innerHTML = '';
-      featureGallery.classList.remove('active');
+      featureGallery.classList.remove('active', 'links-mode');
     }
     stopGalleryLoop();
   }
@@ -1481,77 +1712,37 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function stopLinkLoop() {
-    if (linkAnimationId) {
-      cancelAnimationFrame(linkAnimationId);
-      linkAnimationId = null;
-    }
-    linkTrackEl = null;
-    linkLoopWidth = 0;
-    linkOffset = 0;
-    linkLastTs = 0;
-  }
-
-  function linkStep(timestamp) {
-    if (!linkTrackEl || linkLoopWidth <= 0) {
-      linkAnimationId = null;
-      return;
-    }
-    if (!linkLastTs) linkLastTs = timestamp;
-    const delta = (timestamp - linkLastTs) / 1000;
-    linkLastTs = timestamp;
-    linkOffset = (linkOffset + GALLERY_SPEED * delta) % linkLoopWidth;
-    linkTrackEl.style.transform = `translateX(${-linkOffset}px)`;
-    linkAnimationId = requestAnimationFrame(linkStep);
-  }
-
-  function startLinkLoop(track) {
-    stopLinkLoop();
-    if (!track) return;
-    linkTrackEl = track;
-    linkLoopWidth = track.scrollWidth / 2 || track.scrollWidth;
-    if (linkLoopWidth <= 0) {
-      linkTrackEl = null;
-      return;
-    }
-    linkOffset = 0;
-    linkLastTs = 0;
-    linkAnimationId = requestAnimationFrame(linkStep);
-  }
-
-  function hideLinkPlaceholder() {
-    if (!featureLinkPlaceholder || !featureLinkTrack) return;
-    featureLinkPlaceholder.classList.remove('active');
-    featureLinkPlaceholder.removeAttribute('data-link');
-    featureLinkTrack.innerHTML = '';
-    stopLinkLoop();
-  }
-
-  function showLinkPlaceholder(linkText) {
-    if (!featureLinkPlaceholder || !featureLinkTrack) return;
+  function renderFeatureLinkMarquee(linkText) {
+    if (!featureGallery) return;
+    clearFeatureGallery();
     const trimmed = (linkText || '').trim();
-    if (!trimmed) {
-      hideLinkPlaceholder();
-      return;
-    }
+    if (!trimmed) return;
 
-    featureLinkPlaceholder.classList.add('active');
-    featureLinkPlaceholder.setAttribute('data-link', trimmed);
-    featureLinkTrack.innerHTML = '';
-
-    const repetitions = 8;
-    const total = repetitions * 2;
+    const track = document.createElement('div');
+    track.className = 'feature-gallery-track feature-gallery-track--links';
+    const phrases = Array.from({ length: 6 }, () => trimmed);
+    const total = phrases.length * 2;
     for (let i = 0; i < total; i++) {
       const anchor = document.createElement('a');
       anchor.href = trimmed;
       anchor.target = '_blank';
       anchor.rel = 'noopener noreferrer';
-      anchor.className = 'feature-link-item';
-      anchor.textContent = trimmed;
-      featureLinkTrack.appendChild(anchor);
+      anchor.className = 'feature-gallery-link';
+      anchor.textContent = `${phrases[i % phrases.length]}  `;
+      track.appendChild(anchor);
     }
+    featureGallery.appendChild(track);
+    featureGallery.classList.add('active', 'links-mode');
+    requestAnimationFrame(() => startGalleryLoop(track));
+  }
 
-    requestAnimationFrame(() => startLinkLoop(featureLinkTrack));
+  function hideLinkPlaceholder() {
+    if (!featureLinkPlaceholder) return;
+    featureLinkPlaceholder.classList.remove('active');
+    featureLinkPlaceholder.removeAttribute('data-link');
+    if (featureLinkTrack) {
+      featureLinkTrack.innerHTML = '';
+    }
   }
 
   function openImageOverlay(src) {
@@ -1712,13 +1903,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (!hasVideo && hasImages) {
       renderFeatureGallery(media, label);
-    }
-
-    if (!hasVideo && !hasImages && externalLink) {
-      showLinkPlaceholder(externalLink);
-    }
-
-    if (!hasVideo && !hasImages && !externalLink) {
+    } else if (!hasVideo && !hasImages && externalLink) {
+      renderFeatureLinkMarquee(externalLink);
+    } else if (!hasVideo && !hasImages && !externalLink) {
       featureVideoShell.classList.remove('visible');
       featureVideoShell.style.setProperty('--feature-video-width', '');
     }

--- a/index.html
+++ b/index.html
@@ -44,13 +44,8 @@
       font-family: 'Ferrite Display', sans-serif;
       overflow-x: hidden;
       scrollbar-width: none;
-      cursor: none;
-    }
-
-    html { background: var(--bg-main); }
-
-    body {
-      background: transparent;
+      background-color: var(--bg-main);
+      transition: background-color var(--theme-transition) ease;
     }
 
     body::-webkit-scrollbar {
@@ -59,39 +54,6 @@
 
     .i18n-loading [data-i18n] {
       visibility: hidden;
-    }
-
-    body * {
-      cursor: none !important;
-    }
-
-    #customCursor {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 20px;
-      height: 20px;
-      border-radius: 50%;
-      background: var(--accent);
-      box-shadow: 0 0 0 4px rgba(20, 73, 255, 0.12);
-      transform: translate(-50%, -50%) scale(1);
-      pointer-events: none;
-      z-index: 999;
-      opacity: 0;
-      transition: opacity 0.18s ease, transform 0.18s ease, background var(--theme-transition) ease, box-shadow var(--theme-transition) ease;
-      mix-blend-mode: normal;
-    }
-
-    body.dark-mode #customCursor {
-      box-shadow: 0 0 0 4px rgba(215, 43, 43, 0.15);
-    }
-
-    body.cursor-hidden #customCursor {
-      opacity: 0;
-    }
-
-    body.cursor-active #customCursor {
-      opacity: 1;
     }
 
     /* Language toggle button styling */
@@ -740,7 +702,6 @@
     document.documentElement.classList.add('i18n-loading');
   </script>
 <body>
-  <div id="customCursor" aria-hidden="true"></div>
   <!-- Language switch button -->
   <button id="lang-toggle">FR</button>
 
@@ -839,7 +800,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const featureLinkTrack = document.getElementById('featureLinkTrack');
   const featureImageOverlay = document.getElementById('featureImageOverlay');
   const featureImageOverlayImg = featureImageOverlay ? featureImageOverlay.querySelector('img') : null;
-  const customCursor = document.getElementById('customCursor');
 
   const THEMES = {
     light: { accent: '#1449ff', topoBg: '#faf8e5', topoLine: '#ffffff' },
@@ -864,32 +824,422 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const DIRECT_VIDEO_EXT = /\.(mp4|webm|ogg)(?:\?.*)?$/i;
 
-  let cursorX = 0;
-  let cursorY = 0;
-  let cursorScale = 1;
-  let cursorIsActive = false;
+  const SOUND_FILES = {
+    click: 'click.wav',
+    scroll: 'scroll.wav',
+    scrollTabs: 'scroll_tabs.wav',
+    scrollAuto: 'scroll_auto.wav',
+    interactiveText: 'interactive_text.wav',
+    contactHover: 'contact_hover.wav',
+    imageClick: 'image_click.wav',
+    idHold: 'id.wav',
+    folderHover: 'folder_hover.wav',
+    folderClick: 'folder_click.wav',
+    intro: 'intro.wav',
+    lightBed: 'light_constant.wav',
+    darkBed: 'dark_constant.wav',
+    folderBed: 'folder_constant.wav'
+  };
 
-  function applyCursorTransform(scale = cursorScale) {
-    if (!customCursor) return;
-    cursorScale = scale;
-    customCursor.style.transform = `translate(${cursorX}px, ${cursorY}px) translate(-50%, -50%) scale(${cursorScale})`;
+  function createSoundController() {
+    const AudioCtx = window.AudioContext || window.webkitAudioContext;
+    if (!AudioCtx) {
+      return {
+        supported: false,
+        unlock() {},
+        playClip() {},
+        ensureLoop() { return Promise.resolve(null); },
+        setLoopVolume() {},
+        stopLoop() {},
+        isLoopActive() { return false; }
+      };
+    }
+
+    const SOUND_BASE_PATH = 'SFX/';
+    const ctx = new AudioCtx();
+    const master = ctx.createGain();
+    master.connect(ctx.destination);
+    master.gain.value = 1;
+
+    const buffers = new Map();
+    const loading = new Map();
+    const loops = new Map();
+    const cooldowns = new Map();
+
+    const DEFAULT_FADE_IN = 1;
+    const DEFAULT_FADE_OUT = 3;
+    const DEFAULT_COOLDOWN = 4000;
+
+    function unlock() {
+      if (ctx.state === 'suspended') {
+        ctx.resume().catch(() => {});
+      }
+    }
+
+    function loadBuffer(name) {
+      if (buffers.has(name)) return Promise.resolve(buffers.get(name));
+      if (loading.has(name)) return loading.get(name);
+      const promise = fetch(`${SOUND_BASE_PATH}${name}`)
+        .then(res => res.arrayBuffer())
+        .then(data => ctx.decodeAudioData(data))
+        .then(buffer => {
+          buffers.set(name, buffer);
+          loading.delete(name);
+          return buffer;
+        })
+        .catch(error => {
+          loading.delete(name);
+          console.warn('[audio] failed to load', name, error);
+          return null;
+        });
+      loading.set(name, promise);
+      return promise;
+    }
+
+    function isCoolingDown(name, cooldownMs) {
+      if (!cooldownMs || cooldownMs <= 0) return false;
+      const last = cooldowns.get(name);
+      if (last === undefined) return false;
+      return (performance.now() - last) < cooldownMs;
+    }
+
+    function markCooldown(name, cooldownMs) {
+      if (cooldownMs && cooldownMs > 0) {
+        cooldowns.set(name, performance.now());
+      }
+    }
+
+    function playClip(name, options = {}) {
+      if (!name) return;
+      const {
+        volume = 1,
+        fadeIn = DEFAULT_FADE_IN,
+        fadeOut = DEFAULT_FADE_OUT,
+        playbackRate = 1,
+        duration = null,
+        cooldown = DEFAULT_COOLDOWN,
+        allowOverlap = false
+      } = options;
+      if (!allowOverlap && isCoolingDown(name, cooldown)) return;
+      markCooldown(name, cooldown);
+      unlock();
+      loadBuffer(name).then(buffer => {
+        if (!buffer) return;
+        const now = ctx.currentTime;
+        const source = ctx.createBufferSource();
+        source.buffer = buffer;
+        source.loop = false;
+        source.playbackRate.setValueAtTime(playbackRate, now);
+        const gain = ctx.createGain();
+        gain.gain.setValueAtTime(0.0001, now);
+        source.connect(gain);
+        gain.connect(master);
+        source.start(now);
+        const safeVolume = Math.max(0, volume);
+        if (fadeIn > 0) {
+          gain.gain.linearRampToValueAtTime(safeVolume, now + fadeIn);
+        } else {
+          gain.gain.setValueAtTime(safeVolume, now);
+        }
+        const bufferDuration = buffer.duration / playbackRate;
+        const effectiveDuration = duration ? Math.min(duration, bufferDuration) : bufferDuration;
+        const fadeOutDuration = Math.max(fadeOut, 0.05);
+        const fadeOutStart = Math.max(now + fadeIn, now + effectiveDuration - fadeOutDuration);
+        gain.gain.setValueAtTime(safeVolume, fadeOutStart);
+        gain.gain.linearRampToValueAtTime(0.0001, fadeOutStart + fadeOutDuration);
+        source.stop(fadeOutStart + fadeOutDuration + 0.1);
+      }).catch(() => {});
+    }
+
+    function ensureLoop(name, options = {}) {
+      const existing = loops.get(name);
+      if (existing) {
+        if (typeof options.volume === 'number') {
+          setLoopVolume(name, options.volume, options.ramp);
+        }
+        return Promise.resolve(existing);
+      }
+
+      const cooldownMs = options.cooldown ?? DEFAULT_COOLDOWN;
+      if (isCoolingDown(name, cooldownMs)) {
+        return Promise.resolve(null);
+      }
+      markCooldown(name, cooldownMs);
+      unlock();
+
+      return loadBuffer(name).then(buffer => {
+        if (!buffer) return null;
+        const now = ctx.currentTime;
+        const source = ctx.createBufferSource();
+        source.buffer = buffer;
+        source.loop = true;
+        source.playbackRate.setValueAtTime(options.playbackRate || 1, now);
+        const gain = ctx.createGain();
+        const targetVol = Math.max(0, options.volume ?? 1);
+        gain.gain.setValueAtTime(0.0001, now);
+        source.connect(gain);
+        gain.connect(master);
+        source.start(now);
+        const fadeInDuration = options.fadeIn ?? DEFAULT_FADE_IN;
+        if (fadeInDuration > 0) {
+          gain.gain.linearRampToValueAtTime(targetVol, now + fadeInDuration);
+        } else {
+          gain.gain.setValueAtTime(targetVol, now);
+        }
+        const entry = { source, gain, volumeTarget: targetVol };
+        loops.set(name, entry);
+        return entry;
+      }).catch(() => null);
+    }
+
+    function setLoopVolume(name, volume, ramp = 0.3) {
+      const entry = loops.get(name);
+      if (!entry) return;
+      const now = ctx.currentTime;
+      const target = Math.max(0, typeof volume === 'number' ? volume : entry.volumeTarget);
+      entry.volumeTarget = target;
+      entry.gain.gain.cancelScheduledValues(now);
+      const current = entry.gain.gain.value;
+      entry.gain.gain.setValueAtTime(current, now);
+      const rampDuration = Math.max(0.01, ramp || 0.01);
+      entry.gain.gain.linearRampToValueAtTime(target, now + rampDuration);
+    }
+
+    function stopLoop(name, fadeOut = DEFAULT_FADE_OUT) {
+      const entry = loops.get(name);
+      if (!entry) return;
+      loops.delete(name);
+      const now = ctx.currentTime;
+      const fadeDuration = Math.max(0.05, fadeOut || 0.05);
+      entry.gain.gain.cancelScheduledValues(now);
+      entry.gain.gain.setValueAtTime(entry.gain.gain.value, now);
+      entry.gain.gain.linearRampToValueAtTime(0.0001, now + fadeDuration);
+      try {
+        entry.source.stop(now + fadeDuration + 0.1);
+      } catch (error) {
+        try { entry.source.stop(); } catch (_) {}
+      }
+    }
+
+    function isLoopActive(name) {
+      return loops.has(name);
+    }
+
+    return {
+      supported: true,
+      unlock,
+      playClip,
+      ensureLoop,
+      setLoopVolume,
+      stopLoop,
+      isLoopActive
+    };
   }
 
-  function showCursor() {
-    if (!customCursor) return;
-    cursorIsActive = true;
-    document.body.classList.add('cursor-active');
-    document.body.classList.remove('cursor-hidden');
-    customCursor.style.opacity = '1';
+  const soundController = createSoundController();
+  const audioSupported = Boolean(soundController && soundController.supported);
+  let audioPrimed = false;
+  let introPlayed = false;
+  let folderZoneActive = false;
+  let folderObserverActive = false;
+  let autoScrollActive = false;
+  let autoScrollTimer = null;
+  let scrollStopTimer = null;
+  let scrollTabsStopTimer = null;
+  let lastScrollY = window.scrollY || 0;
+  let lastScrollTime = performance.now();
+
+  function ensureSoundReady() {
+    if (!audioSupported) return;
+    soundController.unlock();
+    if (audioPrimed) return;
+    audioPrimed = true;
+    if (!introPlayed) {
+      soundController.playClip(SOUND_FILES.intro, {
+        volume: 0.55,
+        duration: 7,
+        fadeIn: 1,
+        fadeOut: 3,
+        cooldown: 0,
+        allowOverlap: true
+      });
+      introPlayed = true;
+    }
+    if (folderZoneActive) {
+      soundController.ensureLoop(SOUND_FILES.folderBed, { volume: 0.22, fadeIn: 5, cooldown: 0 });
+      soundController.stopLoop(SOUND_FILES.lightBed, 5);
+      soundController.stopLoop(SOUND_FILES.darkBed, 5);
+    } else {
+      updateThemeConstant(true);
+    }
   }
 
-  function hideCursor() {
-    if (!customCursor) return;
-    cursorIsActive = false;
-    document.body.classList.add('cursor-hidden');
-    document.body.classList.remove('cursor-active');
-    customCursor.style.opacity = '0';
+  function triggerInteractiveTextSound() {
+    if (!audioSupported) return;
+    ensureSoundReady();
+    soundController.playClip(SOUND_FILES.interactiveText, { volume: 0.52 });
   }
+
+  function triggerContactHoverSound() {
+    if (!audioSupported) return;
+    ensureSoundReady();
+    soundController.playClip(SOUND_FILES.contactHover, { volume: 0.58 });
+  }
+
+  function triggerAutoScrollSound(duration) {
+    if (!audioSupported) return;
+    ensureSoundReady();
+    soundController.playClip(SOUND_FILES.scrollAuto, { volume: 0.6 });
+    setAutoScrollState(true, duration + 200);
+  }
+
+  function startIdHoldSound() {
+    if (!audioSupported) return;
+    ensureSoundReady();
+    soundController.ensureLoop(SOUND_FILES.idHold, { volume: 0.55, fadeIn: 1, cooldown: 4000 });
+  }
+
+  function stopIdHoldSound() {
+    if (!audioSupported) return;
+    soundController.stopLoop(SOUND_FILES.idHold, 3);
+  }
+
+  function setAutoScrollState(active, duration = 0) {
+    autoScrollActive = active;
+    if (autoScrollTimer) {
+      clearTimeout(autoScrollTimer);
+      autoScrollTimer = null;
+    }
+    if (active) {
+      if (audioSupported) {
+        soundController.stopLoop(SOUND_FILES.scroll, 0.6);
+        soundController.stopLoop(SOUND_FILES.scrollTabs, 0.6);
+      }
+      if (duration > 0) {
+        autoScrollTimer = window.setTimeout(() => {
+          autoScrollActive = false;
+          autoScrollTimer = null;
+        }, duration);
+      }
+    }
+  }
+
+  function updateThemeConstant(immediate = false) {
+    if (!audioSupported || !audioPrimed || folderZoneActive) return;
+    const fade = immediate ? 0.6 : 1.5;
+    if (currentTheme === 'dark') {
+      soundController.ensureLoop(SOUND_FILES.darkBed, { volume: 0.16, fadeIn: fade, cooldown: 0 });
+      soundController.stopLoop(SOUND_FILES.lightBed, fade);
+    } else {
+      soundController.ensureLoop(SOUND_FILES.lightBed, { volume: 0.16, fadeIn: fade, cooldown: 0 });
+      soundController.stopLoop(SOUND_FILES.darkBed, fade);
+    }
+  }
+
+  function setFolderZoneActive(active) {
+    if (folderZoneActive === active) return;
+    folderZoneActive = active;
+    if (!audioSupported || !audioPrimed) return;
+    if (active) {
+      soundController.ensureLoop(SOUND_FILES.folderBed, { volume: 0.22, fadeIn: 5, cooldown: 0 });
+      soundController.stopLoop(SOUND_FILES.lightBed, 5);
+      soundController.stopLoop(SOUND_FILES.darkBed, 5);
+    } else {
+      soundController.stopLoop(SOUND_FILES.folderBed, 5);
+      updateThemeConstant();
+    }
+  }
+
+  function handleSoundEvent(name) {
+    if (!audioSupported) return;
+    switch (name) {
+      case 'folder-hover':
+        ensureSoundReady();
+        soundController.playClip(SOUND_FILES.folderHover, { volume: 0.5 });
+        break;
+      case 'folder-click':
+        ensureSoundReady();
+        soundController.playClip(SOUND_FILES.folderClick, { volume: 0.64 });
+        break;
+      case 'interactive-text':
+        triggerInteractiveTextSound();
+        break;
+      default:
+        break;
+    }
+  }
+
+  function handleScrollAudio() {
+    if (!audioSupported) return;
+    const now = performance.now();
+    const currentY = window.scrollY;
+    const delta = currentY - lastScrollY;
+    const dt = Math.max(now - lastScrollTime, 16);
+    lastScrollY = currentY;
+    lastScrollTime = now;
+
+    if (autoScrollActive) {
+      if (scrollStopTimer) { clearTimeout(scrollStopTimer); scrollStopTimer = null; }
+      if (scrollTabsStopTimer) { clearTimeout(scrollTabsStopTimer); scrollTabsStopTimer = null; }
+      return;
+    }
+
+    const pxPerSec = Math.abs(delta) / dt * 1000;
+    const intensity = Math.min(pxPerSec / 1400, 1);
+
+    if (intensity > 0.015) {
+      ensureSoundReady();
+      const volume = 0.16 + intensity * 0.36;
+      soundController.ensureLoop(SOUND_FILES.scroll, { volume, fadeIn: 0.6, cooldown: 0 });
+      soundController.setLoopVolume(SOUND_FILES.scroll, volume, 0.25);
+      if (scrollStopTimer) clearTimeout(scrollStopTimer);
+      scrollStopTimer = window.setTimeout(() => {
+        soundController.stopLoop(SOUND_FILES.scroll, 1.6);
+        scrollStopTimer = null;
+      }, 220);
+    } else if (!scrollStopTimer && soundController.isLoopActive(SOUND_FILES.scroll)) {
+      scrollStopTimer = window.setTimeout(() => {
+        soundController.stopLoop(SOUND_FILES.scroll, 1.6);
+        scrollStopTimer = null;
+      }, 220);
+    }
+
+    const inTabsRange = currentY >= window.innerHeight && currentY <= window.innerHeight * 4;
+    if (intensity > 0.02 && inTabsRange) {
+      ensureSoundReady();
+      const tabVolume = 0.12 + intensity * 0.18;
+      soundController.ensureLoop(SOUND_FILES.scrollTabs, { volume: tabVolume, fadeIn: 0.8, cooldown: 0 });
+      soundController.setLoopVolume(SOUND_FILES.scrollTabs, tabVolume, 0.3);
+      if (scrollTabsStopTimer) clearTimeout(scrollTabsStopTimer);
+      scrollTabsStopTimer = window.setTimeout(() => {
+        soundController.stopLoop(SOUND_FILES.scrollTabs, 2);
+        scrollTabsStopTimer = null;
+      }, 260);
+    } else if (!scrollTabsStopTimer && soundController.isLoopActive(SOUND_FILES.scrollTabs)) {
+      scrollTabsStopTimer = window.setTimeout(() => {
+        soundController.stopLoop(SOUND_FILES.scrollTabs, 2);
+        scrollTabsStopTimer = null;
+      }, 200);
+    }
+  }
+
+  function manualFolderZoneCheck() {
+    if (!orbitFrame) return;
+    const rect = orbitFrame.getBoundingClientRect();
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const visible = rect.top < viewportHeight * 0.85 && rect.bottom > viewportHeight * 0.25;
+    setFolderZoneActive(visible);
+  }
+
+  document.addEventListener('pointerdown', event => {
+    if (event.button !== undefined && event.button !== 0) return;
+    ensureSoundReady();
+    if (audioSupported) {
+      soundController.playClip(SOUND_FILES.click, { volume: 0.62 });
+    }
+  }, { passive: true });
+
+  window.addEventListener('keydown', ensureSoundReady, { passive: true });
 
   function isDirectVideoUrl(url = '') {
     return DIRECT_VIDEO_EXT.test(url);
@@ -934,42 +1284,7 @@ document.addEventListener('DOMContentLoaded', () => {
       orbitFrame.contentWindow.postMessage({ theme: { accent: theme.accent } }, '*');
     }
     updateSoundButtonLabel();
-  }
-
-  if (customCursor) {
-    document.addEventListener('pointermove', event => {
-      cursorX = event.clientX;
-      cursorY = event.clientY;
-      applyCursorTransform(cursorScale);
-      showCursor();
-    });
-
-    document.addEventListener('pointerdown', event => {
-      cursorX = event.clientX;
-      cursorY = event.clientY;
-      applyCursorTransform(0.72);
-      showCursor();
-    });
-
-    document.addEventListener('pointerup', event => {
-      cursorX = event.clientX;
-      cursorY = event.clientY;
-      applyCursorTransform(1);
-      showCursor();
-    });
-
-    document.addEventListener('pointercancel', hideCursor);
-    window.addEventListener('blur', hideCursor);
-    window.addEventListener('mouseout', event => {
-      if (!event.relatedTarget && event.target === document.documentElement) {
-        hideCursor();
-      }
-    });
-    window.addEventListener('focus', () => {
-      if (cursorIsActive) {
-        showCursor();
-      }
-    });
+    updateThemeConstant();
   }
 
   function parseAspectRatio(value) {
@@ -1125,7 +1440,13 @@ document.addEventListener('DOMContentLoaded', () => {
       const baseIndex = (index % media.length) + 1;
       img.alt = `${label} preview ${baseIndex}`;
       button.appendChild(img);
-      button.addEventListener('click', () => openImageOverlay(src));
+      button.addEventListener('click', () => {
+        ensureSoundReady();
+        if (audioSupported) {
+          soundController.playClip(SOUND_FILES.imageClick, { volume: 0.6 });
+        }
+        openImageOverlay(src);
+      });
       const sizeHandler = () => adjustGalleryItemSize(button, img);
       if (img.complete && img.naturalWidth > 0 && img.naturalHeight > 0) {
         sizeHandler();
@@ -1412,17 +1733,17 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   if (orbitFrame) {
     orbitFrame.addEventListener('load', () => applyTheme(currentTheme, true));
-    if (customCursor) {
-      orbitFrame.addEventListener('mouseenter', hideCursor);
-      orbitFrame.addEventListener('mouseleave', event => {
-        if (typeof event.clientX === 'number' && typeof event.clientY === 'number') {
-          cursorX = event.clientX;
-          cursorY = event.clientY;
-        }
-        applyCursorTransform(1);
-        showCursor();
+  }
+  if ('IntersectionObserver' in window && orbitFrame) {
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        setFolderZoneActive(entry.isIntersecting && entry.intersectionRatio > 0.25);
       });
-    }
+    }, { threshold: [0, 0.25, 0.5, 0.75, 1] });
+    observer.observe(orbitFrame);
+    folderObserverActive = true;
+  } else if (orbitFrame) {
+    manualFolderZoneCheck();
   }
   applyTheme(currentTheme, true);
   hideFeatureVideo();
@@ -1490,26 +1811,35 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
   function smoothScrollTo(target, duration) {
+    if (!duration || duration <= 0) {
+      window.scrollTo(0, target);
+      return;
+    }
     const start = window.scrollY;
     const diff = target - start;
     const t0 = performance.now();
+    setAutoScrollState(true, duration + 200);
     function step(now) {
       const p = Math.min((now - t0) / duration, 1);
       window.scrollTo(0, start + diff * p);
       if (p < 1) requestAnimationFrame(step);
+      else setAutoScrollState(false);
     }
     requestAnimationFrame(step);
   }
   scrollArrow.addEventListener('click', () => {
     if (goTop) {
       if (gridOpen) {
+        triggerAutoScrollSound(4000);
         pendingScroll = 0;
         orbitFrame.contentWindow.postMessage({ closeGrid: true }, '*');
       } else {
+        triggerAutoScrollSound(4000);
         smoothScrollTo(0, 4000);
       }
       goTop = false;
     } else {
+      triggerAutoScrollSound(4000);
       smoothScrollTo(document.body.scrollHeight, 4000);
       goTop = true;
     }
@@ -1526,12 +1856,21 @@ document.addEventListener('DOMContentLoaded', () => {
     handleScrollClose();
     sendScroll();
     updateScrollbar();
+    handleScrollAudio();
+    if (!folderObserverActive && orbitFrame) {
+      manualFolderZoneCheck();
+    }
   }
   window.addEventListener('scroll', onScroll);
   updateArrow();
   updateScrollbar();
   window.addEventListener('resize', updateScrollbar);
   window.addEventListener('resize', resizeActiveGalleryItems);
+  window.addEventListener('resize', () => {
+    if (!folderObserverActive) {
+      manualFolderZoneCheck();
+    }
+  });
 
   if (featureVideoSound) {
     featureVideoSound.addEventListener('click', () => {
@@ -1584,6 +1923,9 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       if ('showcaseSelection' in e.data) {
         updateFeatureVideo(e.data.showcaseSelection);
+      }
+      if (typeof e.data.soundEvent === 'string') {
+        handleSoundEvent(e.data.soundEvent);
       }
     }
   });
@@ -1649,6 +1991,7 @@ document.addEventListener('DOMContentLoaded', () => {
   contactText.style.pointerEvents = 'auto';
   contactText.addEventListener('mouseenter', () => {
     if (!contactTyped) return;
+    triggerContactHoverSound();
     const now = Date.now();
     if (now - lastSwapTime >= 500) {
       altIndex = (altIndex + 1) % altOptions.length;
@@ -1720,6 +2063,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     letters.forEach((out,i) => {
       out.addEventListener('mouseenter', () => {
+        triggerInteractiveTextSound();
         const wH = baseWidths[i] * S;
         const wN = (i>0?baseWidths[i-1]*S:0)+(i<letters.length-1?baseWidths[i+1]*S:0);
         const wO = totalW - wH - wN;
@@ -1891,8 +2235,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const hit=raycaster.intersectObjects(cardMeshes,false);
         if(!hit.length) return;
         isDown=true; isUp=false; tDownStart=performance.now(); prevDown=0; maskCtx.fillStyle='black'; maskCtx.fillRect(0,0,maskSize,maskSize); maskTexture.needsUpdate=true;
+        startIdHoldSound();
       });
-      window.addEventListener('mouseup',()=>{ if(isDown){ isDown=false; isUp=true; tUpStart=performance.now(); prevUp=0; } });
+      window.addEventListener('mouseup',()=>{ if(isDown){ isDown=false; isUp=true; tUpStart=performance.now(); prevUp=0; } stopIdHoldSound(); });
       const mouse=new THREE.Vector2();
       window.addEventListener('mousemove',e=>{
         const rect=container.getBoundingClientRect();

--- a/index.html
+++ b/index.html
@@ -27,7 +27,6 @@
       --text-primary: #1449ff;
       --topo-light: #ffffff;
       --theme-transition: 1.2s;
-      --theme-background-transition: 1.2s;
     }
 
     body.dark-mode {
@@ -46,7 +45,7 @@
       overflow-x: hidden;
       scrollbar-width: none;
       background-color: var(--bg-main);
-      transition: background-color var(--theme-background-transition) ease;
+      transition: background-color var(--theme-transition) ease;
     }
 
     body::-webkit-scrollbar {
@@ -83,6 +82,71 @@
       font-weight: 700;
       transition: background var(--theme-transition) ease, color var(--theme-transition) ease, border-color var(--theme-transition) ease, opacity 0.25s ease;
       box-sizing: border-box;
+    }
+
+    .top-control-button .icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      height: 100%;
+    }
+
+    .top-control-button svg {
+      width: 28px;
+      height: 28px;
+      display: block;
+      transition: transform 0.25s ease, opacity 0.25s ease;
+    }
+
+    #modeToggle .mode-icon {
+      opacity: 0;
+      transform: scale(0.8);
+      transform-origin: center;
+      transition: opacity 0.25s ease, transform 0.25s ease;
+    }
+
+    #modeToggle[data-mode="light"] .mode-icon--sun,
+    #modeToggle[data-mode="dark"] .mode-icon--moon {
+      opacity: 1;
+      transform: scale(1);
+    }
+
+    #modeToggle path,
+    #modeToggle circle {
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 1.8;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    #soundToggle path {
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 1.8;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      transition: opacity 0.25s ease, transform 0.25s ease;
+    }
+
+    #soundToggle .waves {
+      opacity: 1;
+    }
+
+    #soundToggle.muted .waves {
+      opacity: 0;
+      transform: scale(0.85);
+    }
+
+    #soundToggle .slash {
+      opacity: 0;
+      transform: scale(0.85);
+    }
+
+    #soundToggle.muted .slash {
+      opacity: 1;
+      transform: scale(1);
     }
 
     .top-control-button:focus-visible {
@@ -124,27 +188,6 @@
       padding: 0;
     }
 
-    .interactive-text.reveal-motion {
-      transition: opacity 0.9s ease;
-    }
-
-    .interactive-text .motion-web-canvas {
-      position: absolute;
-      inset: 0;
-      width: 100%;
-      height: 100%;
-      pointer-events: none;
-      opacity: 0;
-      transition: opacity 0.9s ease;
-    }
-
-    .interactive-text.web-mode .motion-web-canvas {
-      pointer-events: auto;
-    }
-
-    .interactive-text.web-mode .letter {
-      pointer-events: none;
-    }
     .interactive-text .letter {
       display: inline-block;
       overflow: hidden;
@@ -168,7 +211,7 @@
       height: 100vh;
       box-sizing: border-box;
       pointer-events: none;
-      z-index: 1;
+      z-index: 3;
     }
     .folder-icon {
       position: relative;
@@ -305,36 +348,6 @@
       z-index: 1;
     }
 
-    #motionWebDock {
-      position: absolute;
-      top: 470vh;
-      left: 50%;
-      transform: translateX(-50%);
-      width: min(88vw, 1280px);
-      height: clamp(220px, 28vw, 420px);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      pointer-events: none;
-      opacity: 0;
-      transition: opacity 1s ease;
-      z-index: 1;
-    }
-
-    #motionWebDock.visible {
-      opacity: 1;
-      pointer-events: auto;
-    }
-
-    #motionWebDock .motion-web-canvas {
-      width: auto;
-      height: auto;
-      max-width: 100%;
-      max-height: 100%;
-      object-fit: contain;
-      pointer-events: auto;
-    }
-
     .page-footer {
       position: absolute;
       top: 642vh;
@@ -377,48 +390,6 @@
       background: var(--bg-main);
       z-index: 3;
       transition: transform 4s cubic-bezier(.33,1,.68,1), background var(--theme-transition) ease, color var(--theme-transition) ease, border-color var(--theme-transition) ease;
-    }
-
-    #modeToggle {
-      font-size: 28px;
-      line-height: 1;
-    }
-
-    #soundToggle .icon {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      pointer-events: none;
-    }
-
-    #soundToggle .icon svg {
-      width: 28px;
-      height: 28px;
-      display: block;
-    }
-
-    #soundToggle .icon path {
-      fill: none;
-      stroke: currentColor;
-      stroke-width: 2;
-      stroke-linecap: round;
-      stroke-linejoin: round;
-      transition: opacity 0.25s ease, transform 0.25s ease;
-    }
-
-    #soundToggle .icon .slash {
-      opacity: 0;
-      transform: scale(0.85);
-    }
-
-    #soundToggle.muted .icon .waves {
-      opacity: 0;
-      transform: scale(0.8);
-    }
-
-    #soundToggle.muted .icon .slash {
-      opacity: 1;
-      transform: scale(1);
     }
 
     #scrollbarTrack {
@@ -464,7 +435,7 @@
       transition: opacity 0.4s ease;
       width: 100vw;
       max-width: 100vw;
-      z-index: 1;
+      z-index: 3;
     }
 
     #featureVideoShell.visible {
@@ -582,28 +553,6 @@
       object-fit: cover;
     }
 
-    .feature-gallery-link {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      height: 100%;
-      padding: 0 clamp(20px, 6vw, 48px);
-      border: 4px solid var(--accent);
-      color: var(--accent);
-      background: var(--bg-alt);
-      text-decoration: none;
-      font-family: 'Ferrite Display', sans-serif;
-      font-size: clamp(18px, 2.2vw, 34px);
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      white-space: nowrap;
-      transition: border-color var(--theme-transition) ease, color var(--theme-transition) ease, background-color var(--theme-transition) ease;
-    }
-
-    .feature-gallery.links-mode .feature-gallery-track {
-      gap: clamp(28px, 5vw, 72px);
-    }
-
     .feature-link-placeholder {
       width: var(--feature-video-width, min(80vw, 960px));
       max-width: min(80vw, 960px);
@@ -651,7 +600,7 @@
 
     .feature-link-placeholder a:hover,
     .feature-link-placeholder a:focus {
-      color: var(--fg-main);
+      color: var(--bg-main);
     }
 
     .feature-image-overlay {
@@ -784,20 +733,6 @@
       overflow: hidden;
     }
 
-    .portfolio-orbit-shell::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      height: clamp(160px, 22%, 260px);
-      background: linear-gradient(to bottom, var(--bg-main) 0%, rgba(20, 73, 255, 0) 75%);
-      pointer-events: none;
-      z-index: 2;
-    }
-
-    body.dark-mode .portfolio-orbit-shell::before {
-      background: linear-gradient(to bottom, var(--bg-main) 0%, rgba(13, 15, 20, 0) 75%);
-    }
-
     .portfolio-orbit {
       position: relative;
       width: 100%;
@@ -806,6 +741,12 @@
       background: transparent;
       display: block;
       z-index: 1;
+      -webkit-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 28%);
+      mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 28%);
+      -webkit-mask-repeat: no-repeat;
+      mask-repeat: no-repeat;
+      -webkit-mask-size: 100% 100%;
+      mask-size: 100% 100%;
     }
     @keyframes dropIn {
       0% {
@@ -845,13 +786,33 @@
 <body>
   <!-- Primary controls -->
   <div id="topControls">
-    <button id="modeToggle" class="top-control-button" type="button" aria-label="Toggle color mode">☾</button>
+    <button id="modeToggle" class="top-control-button" type="button" aria-label="Toggle color mode" data-mode="light">
+      <span class="icon" aria-hidden="true">
+        <svg viewBox="0 0 32 32" role="presentation">
+          <g class="mode-icon mode-icon--sun">
+            <circle cx="16" cy="16" r="5" />
+            <path d="M16 5v3" />
+            <path d="M16 24v3" />
+            <path d="M5 16h3" />
+            <path d="M24 16h3" />
+            <path d="M8.5 8.5l2.1 2.1" />
+            <path d="M21.4 21.4l2.1 2.1" />
+            <path d="M23.5 8.5l-2.1 2.1" />
+            <path d="M10.6 21.4l-2.1 2.1" />
+          </g>
+          <g class="mode-icon mode-icon--moon">
+            <path d="M22.5 20.2A8.5 8.5 0 0 1 12 9.5 7 7 0 0 0 22.5 20.2Z" />
+          </g>
+        </svg>
+      </span>
+    </button>
     <button id="soundToggle" class="top-control-button" type="button" aria-label="Mute sound">
       <span class="icon" aria-hidden="true">
         <svg viewBox="0 0 32 32" role="presentation">
-          <path class="speaker" d="M6 12h6l8-6v20l-8-6H6z" />
-          <path class="waves" d="M22 12c2.2 1.7 3.4 4 3.4 6s-1.2 4.3-3.4 6" />
-          <path class="slash" d="M24 8l6 12" />
+          <path class="speaker" d="M6 12h5.4L18 7v18l-6.6-5H6z" />
+          <path class="waves" d="M21 11c2 1.6 3.1 3.7 3.1 5s-1.1 3.4-3.1 5" />
+          <path class="waves" d="M23.8 8.5c2.9 2.3 4.4 5.2 4.4 7.5s-1.5 5.2-4.4 7.5" />
+          <path class="slash" d="M24 9l6 12" />
         </svg>
       </span>
     </button>
@@ -953,9 +914,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const featureLinkTrack = document.getElementById('featureLinkTrack');
   const featureImageOverlay = document.getElementById('featureImageOverlay');
   const featureImageOverlayImg = featureImageOverlay ? featureImageOverlay.querySelector('img') : null;
-  const motionWebDock = document.getElementById('motionWebDock');
-  const footerParagraph = document.querySelector('.footer-paragraph');
-
   const THEMES = {
     light: { accent: '#1449ff', topoBg: '#faf8e5', topoLine: '#ffffff' },
     dark:  { accent: '#d72b2b', topoBg: '#0d0f14', topoLine: '#1d1f24' }
@@ -965,7 +923,6 @@ document.addEventListener('DOMContentLoaded', () => {
   let currentFeatureVideo = null;
   let currentFeatureAspect = '16:9';
   let featureVideoMuted = true;
-  let motionWebAccent = THEMES[currentTheme].accent;
   let galleryAnimationId = null;
   let galleryTrack = null;
   let galleryLoopWidth = 0;
@@ -990,16 +947,6 @@ document.addEventListener('DOMContentLoaded', () => {
     darkBed: 'dark_constant.wav',
     folderBed: 'folder_constant.wav'
   };
-
-  let motionWebCanvas = null;
-  let motionWebCtx = null;
-  let motionWebPoints = [];
-  let motionWebConnections = [];
-  let motionWebActivePoint = null;
-  let motionWebAnimationFrame = null;
-  let motionWebJitterStrength = 0;
-  let motionWebPinned = false;
-  let motionWebPointerTarget = null;
 
   function createSoundController() {
     const AudioCtx = window.AudioContext || window.webkitAudioContext;
@@ -1582,10 +1529,9 @@ document.addEventListener('DOMContentLoaded', () => {
     document.body.classList.toggle('dark-mode', mode === 'dark');
     if (!skipStorage) localStorage.setItem('ms-theme', mode);
     const theme = THEMES[mode];
-    motionWebAccent = theme.accent;
     if (modeToggle) {
       const isDark = mode === 'dark';
-      modeToggle.textContent = isDark ? '☀' : '☾';
+      modeToggle.setAttribute('data-mode', isDark ? 'dark' : 'light');
       modeToggle.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
     }
     if (bgFrame && bgFrame.contentWindow) {
@@ -1798,27 +1744,29 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function renderFeatureLinkMarquee(linkText) {
-    if (!featureGallery) return;
+    if (!featureLinkPlaceholder || !featureLinkTrack) return;
     clearFeatureGallery();
+    hideLinkPlaceholder();
     const trimmed = (linkText || '').trim();
     if (!trimmed) return;
 
-    const track = document.createElement('div');
-    track.className = 'feature-gallery-track feature-gallery-track--links';
-    const phrases = Array.from({ length: 6 }, () => trimmed);
-    const total = phrases.length * 2;
+    featureLinkTrack.innerHTML = '';
+    featureLinkPlaceholder.classList.add('active');
+    featureLinkPlaceholder.setAttribute('data-link', trimmed);
+
+    const repetitions = 6;
+    const total = repetitions * 2;
     for (let i = 0; i < total; i++) {
       const anchor = document.createElement('a');
       anchor.href = trimmed;
       anchor.target = '_blank';
       anchor.rel = 'noopener noreferrer';
-      anchor.className = 'feature-gallery-link';
-      anchor.textContent = `${phrases[i % phrases.length]}  `;
-      track.appendChild(anchor);
+      anchor.className = 'feature-link-item';
+      anchor.textContent = trimmed;
+      featureLinkTrack.appendChild(anchor);
     }
-    featureGallery.appendChild(track);
-    featureGallery.classList.add('active', 'links-mode');
-    requestAnimationFrame(() => startGalleryLoop(track));
+
+    requestAnimationFrame(() => startGalleryLoop(featureLinkTrack));
   }
 
   function hideLinkPlaceholder() {
@@ -1828,6 +1776,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (featureLinkTrack) {
       featureLinkTrack.innerHTML = '';
     }
+    stopGalleryLoop();
   }
 
   function openImageOverlay(src) {
@@ -2297,7 +2246,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // set stacking & base‐offset for each icon
   const baseOffsets = {};
   sequence.forEach((idx, z) => icons[idx].style.zIndex = 100 - z);
-    sequence.forEach((idx, i) => {
+  sequence.forEach((idx, i) => {
     baseOffsets[idx] = Math.round((i / (sequence.length - 1)) * 50);
   });
 
@@ -2373,231 +2322,6 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  function attachMotionWebPointerHandlers(target) {
-    if (!target) return;
-    if (motionWebPointerTarget === target) return;
-    if (motionWebPointerTarget) {
-      motionWebPointerTarget.removeEventListener('pointermove', handleMotionWebPointerMove);
-      motionWebPointerTarget.removeEventListener('pointerleave', handleMotionWebPointerLeave);
-    }
-    motionWebPointerTarget = target;
-    motionWebPointerTarget.addEventListener('pointermove', handleMotionWebPointerMove);
-    motionWebPointerTarget.addEventListener('pointerleave', handleMotionWebPointerLeave);
-  }
-
-  function handleMotionWebPointerMove(event) {
-    if (!motionWebCanvas) return;
-    const rect = motionWebCanvas.getBoundingClientRect();
-    const x = ((event.clientX - rect.left) / rect.width) * motionWebCanvas.width;
-    const y = ((event.clientY - rect.top) / rect.height) * motionWebCanvas.height;
-    let closest = -1;
-    let bestDist = Infinity;
-    const limit = Math.max(motionWebCanvas.width, motionWebCanvas.height) * 0.12;
-    for (let i = 0; i < motionWebPoints.length; i++) {
-      const pt = motionWebPoints[i];
-      const dx = pt.baseX - x;
-      const dy = pt.baseY - y;
-      const dist = Math.hypot(dx, dy);
-      if (dist < bestDist && dist < limit) {
-        bestDist = dist;
-        closest = i;
-      }
-    }
-    motionWebActivePoint = closest;
-  }
-
-  function handleMotionWebPointerLeave() {
-    motionWebActivePoint = null;
-  }
-
-  function scheduleMotionWebDraw() {
-    if (motionWebAnimationFrame) return;
-    const loop = time => {
-      drawMotionWeb(time || performance.now());
-      motionWebAnimationFrame = requestAnimationFrame(loop);
-    };
-    motionWebAnimationFrame = requestAnimationFrame(loop);
-  }
-
-  function drawMotionWeb(time) {
-    if (!motionWebCtx || !motionWebCanvas) return;
-    const width = motionWebCanvas.width;
-    const height = motionWebCanvas.height;
-    motionWebCtx.clearRect(0, 0, width, height);
-    if (!motionWebPoints.length) return;
-    const accent = (motionWebAccent || '#1449ff').trim();
-    const jitter = motionWebJitterStrength;
-    const timeFactor = time ? time / 1000 : performance.now() / 1000;
-    const wave = motionWebPinned ? 0.6 : 0.2;
-
-    const tempPositions = [];
-    for (let i = 0; i < motionWebPoints.length; i++) {
-      const pt = motionWebPoints[i];
-      const phase = pt.phase || (pt.phase = Math.random() * Math.PI * 2);
-      const jAmp = jitter * 18;
-      const osc = motionWebPinned ? wave * Math.sin(timeFactor * 1.8 + phase) : wave * 0.2 * Math.sin(timeFactor * 1.2 + phase * 0.7);
-      const x = pt.baseX + Math.sin(timeFactor * 1.4 + phase) * jAmp + osc * 4;
-      const y = pt.baseY + Math.cos(timeFactor * 1.1 + phase * 1.3) * jAmp + osc * 6;
-      tempPositions.push({ x, y });
-    }
-
-    motionWebCtx.save();
-    motionWebCtx.lineWidth = 1.3;
-    motionWebCtx.strokeStyle = accent;
-    motionWebCtx.globalAlpha = 0.35;
-    motionWebCtx.beginPath();
-    motionWebConnections.forEach(([a, b]) => {
-      const p1 = tempPositions[a];
-      const p2 = tempPositions[b];
-      if (!p1 || !p2) return;
-      motionWebCtx.moveTo(p1.x, p1.y);
-      motionWebCtx.lineTo(p2.x, p2.y);
-    });
-    motionWebCtx.stroke();
-    if (motionWebActivePoint !== null) {
-      motionWebCtx.globalAlpha = 0.85;
-      motionWebCtx.lineWidth = 2;
-      motionWebCtx.beginPath();
-      motionWebConnections.forEach(([a, b]) => {
-        if (a !== motionWebActivePoint && b !== motionWebActivePoint) return;
-        const p1 = tempPositions[a];
-        const p2 = tempPositions[b];
-        if (!p1 || !p2) return;
-        motionWebCtx.moveTo(p1.x, p1.y);
-        motionWebCtx.lineTo(p2.x, p2.y);
-      });
-      motionWebCtx.stroke();
-    }
-    motionWebCtx.globalAlpha = 1;
-    motionWebCtx.fillStyle = accent;
-    for (let i = 0; i < tempPositions.length; i++) {
-      const pos = tempPositions[i];
-      const active = motionWebActivePoint === i;
-      const radius = active ? 5 : 3;
-      motionWebCtx.beginPath();
-      motionWebCtx.arc(pos.x, pos.y, radius, 0, Math.PI * 2);
-      motionWebCtx.fill();
-    }
-    motionWebCtx.restore();
-  }
-
-  function computeMotionWebData(width, height) {
-    const offscreen = document.createElement('canvas');
-    offscreen.width = width;
-    offscreen.height = height;
-    const ctx = offscreen.getContext('2d');
-    const style = window.getComputedStyle(interactiveText);
-    const fontSize = parseFloat(style.fontSize) || 120;
-    const fontFamily = style.fontFamily || 'Roboto Flex, sans-serif';
-    const fontWeight = parseInt(style.fontWeight, 10) || 400;
-    ctx.clearRect(0, 0, width, height);
-    ctx.fillStyle = '#000';
-    ctx.font = `${fontWeight} ${fontSize}px ${fontFamily}`;
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText(finalText, width / 2, height / 2);
-    const data = ctx.getImageData(0, 0, width, height).data;
-    const step = Math.max(6, Math.round(width / 120));
-    const pts = [];
-    for (let y = step / 2; y < height; y += step) {
-      for (let x = step / 2; x < width; x += step) {
-        const idx = ((y | 0) * width + (x | 0)) * 4 + 3;
-        if (data[idx] > 68) {
-          pts.push({ baseX: x, baseY: y, phase: Math.random() * Math.PI * 2 });
-        }
-      }
-    }
-    if (pts.length > 260) {
-      const keep = 260 / pts.length;
-      motionWebPoints = pts.filter(() => Math.random() < keep);
-    } else {
-      motionWebPoints = pts;
-    }
-    motionWebActivePoint = null;
-    const connectionSet = new Set();
-    motionWebConnections = [];
-    motionWebPoints.forEach((pt, index) => {
-      const candidates = motionWebPoints
-        .map((other, i) => ({ index: i, dist: Math.hypot(other.baseX - pt.baseX, other.baseY - pt.baseY) }))
-        .filter(entry => entry.index !== index)
-        .sort((a, b) => a.dist - b.dist)
-        .slice(0, 4);
-      candidates.forEach(candidate => {
-        const i1 = Math.min(index, candidate.index);
-        const i2 = Math.max(index, candidate.index);
-        const key = `${i1}-${i2}`;
-        if (!connectionSet.has(key)) {
-          connectionSet.add(key);
-          motionWebConnections.push([i1, i2]);
-        }
-      });
-    });
-  }
-
-  function rebuildMotionWeb() {
-    if (!interactiveText) return;
-    const container = motionWebPinned && motionWebDock ? motionWebDock : interactiveText;
-    const width = Math.max(1, Math.round(container.clientWidth || interactiveText.clientWidth));
-    const height = Math.max(1, Math.round(container.clientHeight || interactiveText.clientHeight));
-    if (width <= 0 || height <= 0) return;
-    if (!motionWebCanvas) {
-      motionWebCanvas = document.createElement('canvas');
-      motionWebCanvas.className = 'motion-web-canvas';
-      interactiveText.appendChild(motionWebCanvas);
-      attachMotionWebPointerHandlers(interactiveText);
-    }
-    motionWebCanvas.width = width;
-    motionWebCanvas.height = height;
-    motionWebCanvas.style.width = `${width}px`;
-    motionWebCanvas.style.height = `${height}px`;
-    motionWebCtx = motionWebCanvas.getContext('2d');
-    computeMotionWebData(width, height);
-    scheduleMotionWebDraw();
-    if (!motionWebPinned) {
-      motionWebCanvas.style.opacity = '0';
-    }
-  }
-
-  function setMotionWebPinned(pinned) {
-    if (motionWebPinned === pinned) return;
-    motionWebPinned = pinned;
-    if (!motionWebCanvas) return;
-    if (pinned && motionWebDock) {
-      motionWebDock.appendChild(motionWebCanvas);
-      motionWebDock.classList.add('visible');
-      motionWebCanvas.style.opacity = '1';
-      motionWebDock.setAttribute('aria-hidden', 'false');
-      attachMotionWebPointerHandlers(motionWebDock);
-      requestAnimationFrame(() => rebuildMotionWeb());
-    } else {
-      interactiveText.appendChild(motionWebCanvas);
-      if (motionWebDock) motionWebDock.classList.remove('visible');
-      if (motionWebDock) motionWebDock.setAttribute('aria-hidden', 'true');
-      attachMotionWebPointerHandlers(interactiveText);
-      requestAnimationFrame(() => rebuildMotionWeb());
-    }
-  }
-
-  function revealMotionText() {
-    wrapText(finalText, interactiveText);
-    interactiveText.classList.add('reveal-motion');
-    const previousOpacity = interactiveText.style.opacity;
-    interactiveText.style.opacity = '0';
-    requestAnimationFrame(() => {
-      interactiveText.style.opacity = '1';
-    });
-    setTimeout(() => {
-      interactiveText.classList.remove('reveal-motion');
-      interactiveText.style.opacity = previousOpacity;
-      interactiveText.classList.add('pixelate');
-      setTimeout(() => {
-        interactiveText.classList.remove('pixelate');
-        makeInteractive(interactiveText);
-        requestAnimationFrame(() => rebuildMotionWeb());
-      }, 500);
-    }, 900);
-  }
-
   wrapText(initial, interactiveText);
   typeText(interactiveText, initial, () => {
     setTimeout(() => {
@@ -2607,7 +2331,16 @@ document.addEventListener('DOMContentLoaded', () => {
           interactiveText.children[eraseIdx--].remove();
         } else {
           clearInterval(eraseTimer);
-          setTimeout(revealMotionText, 300);
+          setTimeout(() => {
+            wrapText(finalText, interactiveText);
+            typeText(interactiveText, finalText, () => {
+              interactiveText.classList.add('pixelate');
+              setTimeout(() => {
+                interactiveText.classList.remove('pixelate');
+                makeInteractive(interactiveText);
+              }, 500);
+            });
+          }, 300);
         }
       }, 50);
     }, 500);
@@ -2639,36 +2372,12 @@ document.addEventListener('DOMContentLoaded', () => {
       const lin = Math.min((scrollY - startFade) / (endFade - startFade), 1);
       fadeRatio = 1 - Math.pow(2, -20 * lin);
     }
-    if (contactText) {
-      contactText.style.opacity = 1 - fadeRatio;
-      contactText.style.filter = `blur(${fadeRatio * 10}px)`;
-    }
-    if (descriptionText) {
-      descriptionText.style.opacity = 1 - fadeRatio;
-      descriptionText.style.filter = `blur(${fadeRatio * 10}px)`;
-    }
-
-    const webRatio = Math.max(0, Math.min((scrollY - startFade) / (endFade - startFade), 1));
-    if (interactiveText) {
-      const textOpacity = 1 - webRatio;
-      interactiveText.style.opacity = textOpacity;
-      const blurValue = Math.max(0, (fadeRatio * 10) - webRatio * 6);
-      interactiveText.style.filter = `blur(${blurValue}px)`;
-      if (motionWebCanvas && !motionWebPinned) {
-        motionWebCanvas.style.opacity = `${webRatio}`;
-      }
-      interactiveText.classList.toggle('web-mode', webRatio > 0.05 && !motionWebPinned);
-    }
-
-    motionWebJitterStrength = motionWebPinned ? 0.25 : webRatio;
-
-    if (footerParagraph) {
-      const rect = footerParagraph.getBoundingClientRect();
-      const shouldPin = rect.top < window.innerHeight * 0.75;
-      setMotionWebPinned(shouldPin);
-    }
-
-  sequence.forEach((idx, i) => {
+    [interactiveText, contactText, descriptionText].forEach(el => {
+      if (!el) return;
+      el.style.opacity = 1 - fadeRatio;
+      el.style.filter = `blur(${fadeRatio * 10}px)`;
+    });
+    sequence.forEach((idx, i) => {
       const el    = icons[idx];
       const base  = baseOffsets[idx] || 0;
       const start = i * spacing;
@@ -2679,9 +2388,9 @@ document.addEventListener('DOMContentLoaded', () => {
       el.style.transform = `translateY(-${offsetY}px)`;
     });
   });
-  // sync initial scroll position
+
+  // sync initial scroll position with background
   sendScroll();
-});
 </script>
 
 <div id="idCard"></div>
@@ -2833,8 +2542,6 @@ document.addEventListener('DOMContentLoaded', () => {
   <div class="footer-paragraph" data-i18n="footerDescription">
     Proficient working solo or within a creative team. I’m adept at developing clean and productive workflows and efficient production systems. Detail-focused, sharp eyed for the micro as well as the full picture. Experience working in difficult spaces, musical environnements and challenging deadlines. Passion for developping unique image treatment media and effects. Strong ability with both sober briefs and maximalist detail-heavy scenes. Capable of further developping client ideas by finding creative solutions to design challenges.
   </div>
-
-  <div id="motionWebDock" aria-hidden="true"></div>
 
   <div id="featureVideoShell">
     <div class="feature-media-panel feature-video-frame no-video">

--- a/index.html
+++ b/index.html
@@ -26,7 +26,8 @@
       --bg-alt: #ffffff;
       --text-primary: #1449ff;
       --topo-light: #ffffff;
-      --theme-transition: 1s;
+      --theme-transition: 1.2s;
+      --theme-background-transition: 1.2s;
     }
 
     body.dark-mode {
@@ -45,7 +46,7 @@
       overflow-x: hidden;
       scrollbar-width: none;
       background-color: var(--bg-main);
-      transition: background-color var(--theme-transition) ease;
+      transition: background-color var(--theme-background-transition) ease;
     }
 
     body::-webkit-scrollbar {
@@ -56,85 +57,49 @@
       visibility: hidden;
     }
 
-    #audio-debug-panel {
+    /* Top control buttons */
+    #topControls {
       position: fixed;
       top: 12px;
       left: 12px;
-      padding: 10px 12px;
-      background: rgba(0, 0, 0, 0.65);
-      color: #ffffff;
-      font-family: 'Outfit', sans-serif;
-      font-size: 12px;
-      line-height: 1.4;
-      border-radius: 8px;
-      border: 1px solid rgba(255, 255, 255, 0.35);
-      z-index: 1000;
-      pointer-events: none;
-      min-width: 180px;
-      white-space: pre-line;
-      transition: background-color var(--theme-transition) ease, color var(--theme-transition) ease, border-color var(--theme-transition) ease;
-    }
-
-    body.dark-mode #audio-debug-panel {
-      background: rgba(13, 15, 20, 0.78);
-      border-color: rgba(215, 43, 43, 0.45);
-      color: #f4f4f4;
-    }
-
-    #audio-debug-panel strong {
-      display: block;
-      font-weight: 600;
-      letter-spacing: 0.05em;
-      margin-bottom: 4px;
-      text-transform: uppercase;
-    }
-
-    #audio-debug-panel ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
       display: flex;
-      flex-direction: column;
-      gap: 2px;
-    }
-
-    #audio-debug-panel li {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
       gap: 16px;
-      font-family: 'Ferrite Display', sans-serif;
-      font-size: 11px;
-      letter-spacing: 0.08em;
+      z-index: 4;
+      align-items: center;
     }
 
-    #audio-debug-panel .audio-debug-empty {
-      opacity: 0.7;
-      font-style: italic;
-      font-family: 'Outfit', sans-serif;
-      letter-spacing: 0.04em;
-    }
-
-    /* Language toggle button styling */
-    #lang-toggle {
-      position: fixed;
-      top: 12px;
-      left: calc(12px + 60px + 16px);
-      min-width: 0;
+    .top-control-button {
+      width: 60px;
       height: 60px;
       display: flex;
       align-items: center;
       justify-content: center;
       border: 4px solid var(--accent);
       background: var(--bg-main);
-      cursor: pointer;
-      z-index: 3;
       color: var(--accent);
+      cursor: pointer;
+      font-family: 'Ferrite Display', sans-serif;
       font-size: 24px;
       font-weight: 700;
-      transition: background var(--theme-transition) ease, color var(--theme-transition) ease, border-color var(--theme-transition) ease;
+      transition: background var(--theme-transition) ease, color var(--theme-transition) ease, border-color var(--theme-transition) ease, opacity 0.25s ease;
       box-sizing: border-box;
+    }
+
+    .top-control-button:focus-visible {
+      outline: 3px solid currentColor;
+      outline-offset: 3px;
+    }
+
+    .top-control-button:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
+    #lang-toggle {
+      min-width: 60px;
+      width: auto;
       padding: 0 18px;
+      letter-spacing: 0.08em;
     }
 
     iframe#topo-bg { position: fixed; top: 0; left: 0; width: 100%; height: 100%; border: none; z-index: 0; pointer-events: none; }
@@ -157,6 +122,28 @@
       box-sizing: border-box;
       z-index: 0;
       padding: 0;
+    }
+
+    .interactive-text.reveal-motion {
+      transition: opacity 0.9s ease;
+    }
+
+    .interactive-text .motion-web-canvas {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.9s ease;
+    }
+
+    .interactive-text.web-mode .motion-web-canvas {
+      pointer-events: auto;
+    }
+
+    .interactive-text.web-mode .letter {
+      pointer-events: none;
     }
     .interactive-text .letter {
       display: inline-block;
@@ -318,6 +305,36 @@
       z-index: 1;
     }
 
+    #motionWebDock {
+      position: absolute;
+      top: 470vh;
+      left: 50%;
+      transform: translateX(-50%);
+      width: min(88vw, 1280px);
+      height: clamp(220px, 28vw, 420px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 1s ease;
+      z-index: 1;
+    }
+
+    #motionWebDock.visible {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    #motionWebDock .motion-web-canvas {
+      width: auto;
+      height: auto;
+      max-width: 100%;
+      max-height: 100%;
+      object-fit: contain;
+      pointer-events: auto;
+    }
+
     .page-footer {
       position: absolute;
       top: 642vh;
@@ -363,26 +380,45 @@
     }
 
     #modeToggle {
-      position: fixed;
-      top: 12px;
-      left: 12px;
-      width: 60px;
-      height: 60px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      border: 4px solid var(--accent);
-      color: var(--accent);
-      background: var(--bg-main);
-      cursor: pointer;
-      font-size: 24px;
-      font-weight: 700;
-      z-index: 3;
-      transition: background var(--theme-transition) ease, color var(--theme-transition) ease, border-color var(--theme-transition) ease;
+      font-size: 28px;
+      line-height: 1;
     }
 
-    body.dark-mode #modeToggle {
-      background: var(--bg-main);
+    #soundToggle .icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      pointer-events: none;
+    }
+
+    #soundToggle .icon svg {
+      width: 28px;
+      height: 28px;
+      display: block;
+    }
+
+    #soundToggle .icon path {
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 2;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      transition: opacity 0.25s ease, transform 0.25s ease;
+    }
+
+    #soundToggle .icon .slash {
+      opacity: 0;
+      transform: scale(0.85);
+    }
+
+    #soundToggle.muted .icon .waves {
+      opacity: 0;
+      transform: scale(0.8);
+    }
+
+    #soundToggle.muted .icon .slash {
+      opacity: 1;
+      transform: scale(1);
     }
 
     #scrollbarTrack {
@@ -543,7 +579,7 @@
       height: 100%;
       width: 100%;
       display: block;
-      object-fit: contain;
+      object-fit: cover;
     }
 
     .feature-gallery-link {
@@ -738,14 +774,37 @@
       transform: scale(1);
     }
 
-    .portfolio-orbit {
+    .portfolio-orbit-shell {
       position: absolute;
       top: 550vh;
       left: 0;
       width: 100vw;
       height: clamp(620px, 100vh, 1080px);
+      z-index: 1;
+      overflow: hidden;
+    }
+
+    .portfolio-orbit-shell::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      height: clamp(160px, 22%, 260px);
+      background: linear-gradient(to bottom, var(--bg-main) 0%, rgba(20, 73, 255, 0) 75%);
+      pointer-events: none;
+      z-index: 2;
+    }
+
+    body.dark-mode .portfolio-orbit-shell::before {
+      background: linear-gradient(to bottom, var(--bg-main) 0%, rgba(13, 15, 20, 0) 75%);
+    }
+
+    .portfolio-orbit {
+      position: relative;
+      width: 100%;
+      height: 100%;
       border: none;
       background: transparent;
+      display: block;
       z-index: 1;
     }
     @keyframes dropIn {
@@ -784,8 +843,20 @@
     document.documentElement.classList.add('i18n-loading');
   </script>
 <body>
-  <!-- Language switch button -->
-  <button id="lang-toggle">FR</button>
+  <!-- Primary controls -->
+  <div id="topControls">
+    <button id="modeToggle" class="top-control-button" type="button" aria-label="Toggle color mode">☾</button>
+    <button id="soundToggle" class="top-control-button" type="button" aria-label="Mute sound">
+      <span class="icon" aria-hidden="true">
+        <svg viewBox="0 0 32 32" role="presentation">
+          <path class="speaker" d="M6 12h6l8-6v20l-8-6H6z" />
+          <path class="waves" d="M22 12c2.2 1.7 3.4 4 3.4 6s-1.2 4.3-3.4 6" />
+          <path class="slash" d="M24 8l6 12" />
+        </svg>
+      </span>
+    </button>
+    <button id="lang-toggle" class="top-control-button" type="button">FR</button>
+  </div>
 
   <iframe id="topo-bg" src="topo.html" scrolling="no" loading="eager" title="Topographic background"></iframe>
 
@@ -794,7 +865,6 @@
       <path d="M12 4v16m0 0-6-6m6 6 6-6" stroke="currentColor" stroke-width="3" fill="none" stroke-linecap="square" stroke-linejoin="miter"/>
     </svg>
   </div>
-  <button id="modeToggle" aria-label="Toggle color mode">☾</button>
   <div id="scrollbarTrack" aria-hidden="true"><div id="scrollbarProgress"></div></div>
 
   <!-- Contact and description -->
@@ -870,6 +940,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const orbitFrame      = document.querySelector('iframe[src="orbit_inner.html"]');
   const scrollArrow       = document.getElementById('scrollArrow');
   const modeToggle        = document.getElementById('modeToggle');
+  const soundToggle       = document.getElementById('soundToggle');
   const scrollbarProgress = document.getElementById('scrollbarProgress');
   const featureVideoShell = document.getElementById('featureVideoShell');
   const featureVideoFrame = featureVideoShell ? featureVideoShell.querySelector('.feature-video-frame') : null;
@@ -882,6 +953,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const featureLinkTrack = document.getElementById('featureLinkTrack');
   const featureImageOverlay = document.getElementById('featureImageOverlay');
   const featureImageOverlayImg = featureImageOverlay ? featureImageOverlay.querySelector('img') : null;
+  const motionWebDock = document.getElementById('motionWebDock');
+  const footerParagraph = document.querySelector('.footer-paragraph');
 
   const THEMES = {
     light: { accent: '#1449ff', topoBg: '#faf8e5', topoLine: '#ffffff' },
@@ -892,6 +965,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let currentFeatureVideo = null;
   let currentFeatureAspect = '16:9';
   let featureVideoMuted = true;
+  let motionWebAccent = THEMES[currentTheme].accent;
   let galleryAnimationId = null;
   let galleryTrack = null;
   let galleryLoopWidth = 0;
@@ -917,6 +991,16 @@ document.addEventListener('DOMContentLoaded', () => {
     folderBed: 'folder_constant.wav'
   };
 
+  let motionWebCanvas = null;
+  let motionWebCtx = null;
+  let motionWebPoints = [];
+  let motionWebConnections = [];
+  let motionWebActivePoint = null;
+  let motionWebAnimationFrame = null;
+  let motionWebJitterStrength = 0;
+  let motionWebPinned = false;
+  let motionWebPointerTarget = null;
+
   function createSoundController() {
     const AudioCtx = window.AudioContext || window.webkitAudioContext;
     if (!AudioCtx) {
@@ -938,6 +1022,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const master = ctx.createGain();
     master.connect(ctx.destination);
     master.gain.value = 1;
+    let masterMuted = false;
 
     const buffers = new Map();
     const loading = new Map();
@@ -1024,6 +1109,19 @@ document.addEventListener('DOMContentLoaded', () => {
       if (ctx.state === 'suspended') {
         ctx.resume().catch(() => {});
       }
+    }
+
+    function setMuted(muted) {
+      masterMuted = Boolean(muted);
+      const now = ctx.currentTime;
+      const target = masterMuted ? 0.0001 : 1;
+      master.gain.cancelScheduledValues(now);
+      master.gain.setValueAtTime(master.gain.value, now);
+      master.gain.linearRampToValueAtTime(target, now + 0.2);
+    }
+
+    function isMuted() {
+      return masterMuted;
     }
 
     function loadBuffer(name) {
@@ -1189,6 +1287,8 @@ document.addEventListener('DOMContentLoaded', () => {
       setLoopVolume,
       stopLoop,
       isLoopActive,
+      setMuted,
+      isMuted,
       getActiveSounds: snapshotActiveSounds,
       onActiveChange(callback) {
         if (typeof callback !== 'function') {
@@ -1209,60 +1309,40 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const soundController = createSoundController();
   const audioSupported = Boolean(soundController && soundController.supported);
-  const audioDebugPanel = document.createElement('div');
-  audioDebugPanel.id = 'audio-debug-panel';
-  const audioDebugTitle = document.createElement('strong');
-  audioDebugTitle.textContent = 'Audio Monitor';
-  const audioDebugEmpty = document.createElement('div');
-  audioDebugEmpty.className = 'audio-debug-empty';
-  const audioDebugList = document.createElement('ul');
-  audioDebugPanel.append(audioDebugTitle, audioDebugEmpty, audioDebugList);
-  document.body.appendChild(audioDebugPanel);
+  let globalSoundMuted = localStorage.getItem('ms-sound-muted') === '1';
 
-  function updateAudioDebugPanel(sounds = []) {
-    if (!audioSupported) {
-      audioDebugEmpty.textContent = 'Audio unavailable';
-      audioDebugEmpty.style.display = 'block';
-      audioDebugList.style.display = 'none';
-      audioDebugList.innerHTML = '';
-      return;
-    }
-    const entries = Array.isArray(sounds) ? sounds.slice().sort((a, b) => a.name.localeCompare(b.name)) : [];
-    if (!entries.length) {
-      audioDebugEmpty.textContent = 'No audio active';
-      audioDebugEmpty.style.display = 'block';
-      audioDebugList.style.display = 'none';
-      audioDebugList.innerHTML = '';
-      return;
-    }
-    audioDebugEmpty.style.display = 'none';
-    audioDebugList.style.display = 'flex';
-    audioDebugList.innerHTML = '';
-    entries.forEach(sound => {
-      const item = document.createElement('li');
-      const nameSpan = document.createElement('span');
-      nameSpan.textContent = sound.name;
-      const statusSpan = document.createElement('span');
-      let statusText = sound.loop ? 'looping' : 'one-shot';
-      if (!sound.loop && sound.count && sound.count > 1) {
-        statusText += ` ×${sound.count}`;
-      }
-      if (sound.fading) {
-        statusText += ' (fading)';
-      }
-      statusSpan.textContent = statusText;
-      item.append(nameSpan, statusSpan);
-      audioDebugList.appendChild(item);
-    });
+  if (audioSupported && typeof soundController.setMuted === 'function') {
+    soundController.setMuted(globalSoundMuted);
   }
 
-  const initialActive = typeof soundController.getActiveSounds === 'function'
-    ? soundController.getActiveSounds()
-    : [];
-  updateAudioDebugPanel(initialActive);
-  if (typeof soundController.onActiveChange === 'function') {
-    soundController.onActiveChange(updateAudioDebugPanel);
+  function updateSoundToggleState() {
+    if (!soundToggle) return;
+    const label = !audioSupported
+      ? 'Sound unavailable'
+      : globalSoundMuted
+        ? 'Enable sound'
+        : 'Mute sound';
+    soundToggle.classList.toggle('muted', globalSoundMuted);
+    soundToggle.disabled = !audioSupported;
+    soundToggle.setAttribute('aria-pressed', globalSoundMuted ? 'true' : 'false');
+    soundToggle.setAttribute('aria-label', label);
   }
+
+  function setGlobalSoundMuted(muted, { persist = true } = {}) {
+    globalSoundMuted = Boolean(muted);
+    if (audioSupported && typeof soundController.setMuted === 'function') {
+      soundController.setMuted(globalSoundMuted);
+    }
+    if (persist) {
+      localStorage.setItem('ms-sound-muted', globalSoundMuted ? '1' : '0');
+    }
+    updateSoundToggleState();
+    if (!globalSoundMuted) {
+      ensureSoundReady();
+    }
+  }
+
+  updateSoundToggleState();
 
   let audioPrimed = false;
   let introPlayed = false;
@@ -1278,6 +1358,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function ensureSoundReady() {
     if (!audioSupported) return;
     soundController.unlock();
+    if (globalSoundMuted) return;
     if (audioPrimed) return;
     audioPrimed = true;
     if (!introPlayed) {
@@ -1301,26 +1382,26 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function triggerInteractiveTextSound() {
-    if (!audioSupported) return;
+    if (!audioSupported || globalSoundMuted) return;
     ensureSoundReady();
     soundController.playClip(SOUND_FILES.interactiveText, { volume: 0.52 });
   }
 
   function triggerContactHoverSound() {
-    if (!audioSupported) return;
+    if (!audioSupported || globalSoundMuted) return;
     ensureSoundReady();
     soundController.playClip(SOUND_FILES.contactHover, { volume: 0.58 });
   }
 
   function triggerAutoScrollSound(duration) {
-    if (!audioSupported) return;
+    if (!audioSupported || globalSoundMuted) return;
     ensureSoundReady();
     soundController.playClip(SOUND_FILES.scrollAuto, { volume: 0.6 });
     setAutoScrollState(true, duration + 200);
   }
 
   function startIdHoldSound() {
-    if (!audioSupported) return;
+    if (!audioSupported || globalSoundMuted) return;
     ensureSoundReady();
     soundController.ensureLoop(SOUND_FILES.idHold, { volume: 0.55, fadeIn: 1, cooldown: 4000 });
   }
@@ -1338,8 +1419,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if (active) {
       if (audioSupported) {
-        soundController.stopLoop(SOUND_FILES.scroll, 0.6);
-        soundController.stopLoop(SOUND_FILES.scrollTabs, 0.6);
+        soundController.stopLoop(SOUND_FILES.scroll, 3);
+        soundController.stopLoop(SOUND_FILES.scrollTabs, 3);
       }
       if (duration > 0) {
         autoScrollTimer = window.setTimeout(() => {
@@ -1351,7 +1432,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function updateThemeConstant(immediate = false) {
-    if (!audioSupported || !audioPrimed || folderZoneActive) return;
+    if (!audioSupported || !audioPrimed || folderZoneActive || globalSoundMuted) return;
     const fade = immediate ? 0.6 : 1.5;
     if (currentTheme === 'dark') {
       soundController.ensureLoop(SOUND_FILES.darkBed, { volume: 0.16, fadeIn: fade, cooldown: 0 });
@@ -1367,17 +1448,20 @@ document.addEventListener('DOMContentLoaded', () => {
     folderZoneActive = active;
     if (!audioSupported || !audioPrimed) return;
     if (active) {
+      if (globalSoundMuted) return;
       soundController.ensureLoop(SOUND_FILES.folderBed, { volume: 0.22, fadeIn: 5, cooldown: 0 });
       soundController.stopLoop(SOUND_FILES.lightBed, 5);
       soundController.stopLoop(SOUND_FILES.darkBed, 5);
     } else {
       soundController.stopLoop(SOUND_FILES.folderBed, 5);
-      updateThemeConstant();
+      if (!globalSoundMuted) {
+        updateThemeConstant();
+      }
     }
   }
 
   function handleSoundEvent(name) {
-    if (!audioSupported) return;
+    if (!audioSupported || globalSoundMuted) return;
     switch (name) {
       case 'folder-hover':
         ensureSoundReady();
@@ -1396,7 +1480,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function handleScrollAudio() {
-    if (!audioSupported) return;
+    if (!audioSupported || globalSoundMuted) return;
     const now = performance.now();
     const currentY = window.scrollY;
     const delta = currentY - lastScrollY;
@@ -1416,16 +1500,16 @@ document.addEventListener('DOMContentLoaded', () => {
     if (intensity > 0.015) {
       ensureSoundReady();
       const volume = 0.16 + intensity * 0.36;
-      soundController.ensureLoop(SOUND_FILES.scroll, { volume, fadeIn: 0.6, cooldown: 0 });
-      soundController.setLoopVolume(SOUND_FILES.scroll, volume, 0.25);
+      soundController.ensureLoop(SOUND_FILES.scroll, { volume, fadeIn: 1 });
+      soundController.setLoopVolume(SOUND_FILES.scroll, volume, 0.3);
       if (scrollStopTimer) clearTimeout(scrollStopTimer);
       scrollStopTimer = window.setTimeout(() => {
-        soundController.stopLoop(SOUND_FILES.scroll, 1.6);
+        soundController.stopLoop(SOUND_FILES.scroll, 3);
         scrollStopTimer = null;
       }, 220);
     } else if (!scrollStopTimer && soundController.isLoopActive(SOUND_FILES.scroll)) {
       scrollStopTimer = window.setTimeout(() => {
-        soundController.stopLoop(SOUND_FILES.scroll, 1.6);
+        soundController.stopLoop(SOUND_FILES.scroll, 3);
         scrollStopTimer = null;
       }, 220);
     }
@@ -1434,16 +1518,16 @@ document.addEventListener('DOMContentLoaded', () => {
     if (intensity > 0.02 && inTabsRange) {
       ensureSoundReady();
       const tabVolume = 0.12 + intensity * 0.18;
-      soundController.ensureLoop(SOUND_FILES.scrollTabs, { volume: tabVolume, fadeIn: 0.8, cooldown: 0 });
+      soundController.ensureLoop(SOUND_FILES.scrollTabs, { volume: tabVolume, fadeIn: 1 });
       soundController.setLoopVolume(SOUND_FILES.scrollTabs, tabVolume, 0.3);
       if (scrollTabsStopTimer) clearTimeout(scrollTabsStopTimer);
       scrollTabsStopTimer = window.setTimeout(() => {
-        soundController.stopLoop(SOUND_FILES.scrollTabs, 2);
+        soundController.stopLoop(SOUND_FILES.scrollTabs, 3);
         scrollTabsStopTimer = null;
       }, 260);
     } else if (!scrollTabsStopTimer && soundController.isLoopActive(SOUND_FILES.scrollTabs)) {
       scrollTabsStopTimer = window.setTimeout(() => {
-        soundController.stopLoop(SOUND_FILES.scrollTabs, 2);
+        soundController.stopLoop(SOUND_FILES.scrollTabs, 3);
         scrollTabsStopTimer = null;
       }, 200);
     }
@@ -1460,7 +1544,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('pointerdown', event => {
     if (event.button !== undefined && event.button !== 0) return;
     ensureSoundReady();
-    if (audioSupported) {
+    if (audioSupported && !globalSoundMuted) {
       soundController.playClip(SOUND_FILES.click, { volume: 0.62 });
     }
   }, { passive: true });
@@ -1498,6 +1582,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.body.classList.toggle('dark-mode', mode === 'dark');
     if (!skipStorage) localStorage.setItem('ms-theme', mode);
     const theme = THEMES[mode];
+    motionWebAccent = theme.accent;
     if (modeToggle) {
       const isDark = mode === 'dark';
       modeToggle.textContent = isDark ? '☀' : '☾';
@@ -1673,7 +1758,7 @@ document.addEventListener('DOMContentLoaded', () => {
       button.appendChild(img);
       button.addEventListener('click', () => {
         ensureSoundReady();
-        if (audioSupported) {
+        if (audioSupported && !globalSoundMuted) {
           soundController.playClip(SOUND_FILES.imageClick, { volume: 0.6 });
         }
         openImageOverlay(src);
@@ -1832,6 +1917,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const media = Array.isArray(entry.media) ? entry.media.filter(Boolean) : [];
     const hasImages = media.length > 0;
     const externalLink = typeof entry.externalLink === 'string' ? entry.externalLink.trim() : '';
+    const folderName = typeof selection.folder === 'string' ? selection.folder.trim().toLowerCase() : '';
+    const shouldRenderLinkMarquee = !hasVideo && !!externalLink && folderName === 'web';
 
     featureVideoShell.classList.add('visible');
     if (featureVideoPlaceholder) {
@@ -1901,7 +1988,9 @@ document.addEventListener('DOMContentLoaded', () => {
       setVideoMutedState(true);
     }
 
-    if (!hasVideo && hasImages) {
+    if (shouldRenderLinkMarquee) {
+      renderFeatureLinkMarquee(externalLink);
+    } else if (!hasVideo && hasImages) {
       renderFeatureGallery(media, label);
     } else if (!hasVideo && !hasImages && externalLink) {
       renderFeatureLinkMarquee(externalLink);
@@ -2070,11 +2159,19 @@ document.addEventListener('DOMContentLoaded', () => {
     if (featureVideoShell && featureVideoShell.classList.contains('visible')) {
       setFeatureVideoDimensions(currentFeatureAspect);
     }
+    requestAnimationFrame(() => rebuildMotionWeb());
   });
 
   if (modeToggle) {
     modeToggle.addEventListener('click', () => {
       applyTheme(currentTheme === 'light' ? 'dark' : 'light');
+    });
+  }
+
+  if (soundToggle) {
+    soundToggle.addEventListener('click', () => {
+      if (!audioSupported) return;
+      setGlobalSoundMuted(!globalSoundMuted);
     });
   }
 
@@ -2200,7 +2297,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // set stacking & base‐offset for each icon
   const baseOffsets = {};
   sequence.forEach((idx, z) => icons[idx].style.zIndex = 100 - z);
-  sequence.forEach((idx, i) => {
+    sequence.forEach((idx, i) => {
     baseOffsets[idx] = Math.round((i / (sequence.length - 1)) * 50);
   });
 
@@ -2276,6 +2373,231 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  function attachMotionWebPointerHandlers(target) {
+    if (!target) return;
+    if (motionWebPointerTarget === target) return;
+    if (motionWebPointerTarget) {
+      motionWebPointerTarget.removeEventListener('pointermove', handleMotionWebPointerMove);
+      motionWebPointerTarget.removeEventListener('pointerleave', handleMotionWebPointerLeave);
+    }
+    motionWebPointerTarget = target;
+    motionWebPointerTarget.addEventListener('pointermove', handleMotionWebPointerMove);
+    motionWebPointerTarget.addEventListener('pointerleave', handleMotionWebPointerLeave);
+  }
+
+  function handleMotionWebPointerMove(event) {
+    if (!motionWebCanvas) return;
+    const rect = motionWebCanvas.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width) * motionWebCanvas.width;
+    const y = ((event.clientY - rect.top) / rect.height) * motionWebCanvas.height;
+    let closest = -1;
+    let bestDist = Infinity;
+    const limit = Math.max(motionWebCanvas.width, motionWebCanvas.height) * 0.12;
+    for (let i = 0; i < motionWebPoints.length; i++) {
+      const pt = motionWebPoints[i];
+      const dx = pt.baseX - x;
+      const dy = pt.baseY - y;
+      const dist = Math.hypot(dx, dy);
+      if (dist < bestDist && dist < limit) {
+        bestDist = dist;
+        closest = i;
+      }
+    }
+    motionWebActivePoint = closest;
+  }
+
+  function handleMotionWebPointerLeave() {
+    motionWebActivePoint = null;
+  }
+
+  function scheduleMotionWebDraw() {
+    if (motionWebAnimationFrame) return;
+    const loop = time => {
+      drawMotionWeb(time || performance.now());
+      motionWebAnimationFrame = requestAnimationFrame(loop);
+    };
+    motionWebAnimationFrame = requestAnimationFrame(loop);
+  }
+
+  function drawMotionWeb(time) {
+    if (!motionWebCtx || !motionWebCanvas) return;
+    const width = motionWebCanvas.width;
+    const height = motionWebCanvas.height;
+    motionWebCtx.clearRect(0, 0, width, height);
+    if (!motionWebPoints.length) return;
+    const accent = (motionWebAccent || '#1449ff').trim();
+    const jitter = motionWebJitterStrength;
+    const timeFactor = time ? time / 1000 : performance.now() / 1000;
+    const wave = motionWebPinned ? 0.6 : 0.2;
+
+    const tempPositions = [];
+    for (let i = 0; i < motionWebPoints.length; i++) {
+      const pt = motionWebPoints[i];
+      const phase = pt.phase || (pt.phase = Math.random() * Math.PI * 2);
+      const jAmp = jitter * 18;
+      const osc = motionWebPinned ? wave * Math.sin(timeFactor * 1.8 + phase) : wave * 0.2 * Math.sin(timeFactor * 1.2 + phase * 0.7);
+      const x = pt.baseX + Math.sin(timeFactor * 1.4 + phase) * jAmp + osc * 4;
+      const y = pt.baseY + Math.cos(timeFactor * 1.1 + phase * 1.3) * jAmp + osc * 6;
+      tempPositions.push({ x, y });
+    }
+
+    motionWebCtx.save();
+    motionWebCtx.lineWidth = 1.3;
+    motionWebCtx.strokeStyle = accent;
+    motionWebCtx.globalAlpha = 0.35;
+    motionWebCtx.beginPath();
+    motionWebConnections.forEach(([a, b]) => {
+      const p1 = tempPositions[a];
+      const p2 = tempPositions[b];
+      if (!p1 || !p2) return;
+      motionWebCtx.moveTo(p1.x, p1.y);
+      motionWebCtx.lineTo(p2.x, p2.y);
+    });
+    motionWebCtx.stroke();
+    if (motionWebActivePoint !== null) {
+      motionWebCtx.globalAlpha = 0.85;
+      motionWebCtx.lineWidth = 2;
+      motionWebCtx.beginPath();
+      motionWebConnections.forEach(([a, b]) => {
+        if (a !== motionWebActivePoint && b !== motionWebActivePoint) return;
+        const p1 = tempPositions[a];
+        const p2 = tempPositions[b];
+        if (!p1 || !p2) return;
+        motionWebCtx.moveTo(p1.x, p1.y);
+        motionWebCtx.lineTo(p2.x, p2.y);
+      });
+      motionWebCtx.stroke();
+    }
+    motionWebCtx.globalAlpha = 1;
+    motionWebCtx.fillStyle = accent;
+    for (let i = 0; i < tempPositions.length; i++) {
+      const pos = tempPositions[i];
+      const active = motionWebActivePoint === i;
+      const radius = active ? 5 : 3;
+      motionWebCtx.beginPath();
+      motionWebCtx.arc(pos.x, pos.y, radius, 0, Math.PI * 2);
+      motionWebCtx.fill();
+    }
+    motionWebCtx.restore();
+  }
+
+  function computeMotionWebData(width, height) {
+    const offscreen = document.createElement('canvas');
+    offscreen.width = width;
+    offscreen.height = height;
+    const ctx = offscreen.getContext('2d');
+    const style = window.getComputedStyle(interactiveText);
+    const fontSize = parseFloat(style.fontSize) || 120;
+    const fontFamily = style.fontFamily || 'Roboto Flex, sans-serif';
+    const fontWeight = parseInt(style.fontWeight, 10) || 400;
+    ctx.clearRect(0, 0, width, height);
+    ctx.fillStyle = '#000';
+    ctx.font = `${fontWeight} ${fontSize}px ${fontFamily}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(finalText, width / 2, height / 2);
+    const data = ctx.getImageData(0, 0, width, height).data;
+    const step = Math.max(6, Math.round(width / 120));
+    const pts = [];
+    for (let y = step / 2; y < height; y += step) {
+      for (let x = step / 2; x < width; x += step) {
+        const idx = ((y | 0) * width + (x | 0)) * 4 + 3;
+        if (data[idx] > 68) {
+          pts.push({ baseX: x, baseY: y, phase: Math.random() * Math.PI * 2 });
+        }
+      }
+    }
+    if (pts.length > 260) {
+      const keep = 260 / pts.length;
+      motionWebPoints = pts.filter(() => Math.random() < keep);
+    } else {
+      motionWebPoints = pts;
+    }
+    motionWebActivePoint = null;
+    const connectionSet = new Set();
+    motionWebConnections = [];
+    motionWebPoints.forEach((pt, index) => {
+      const candidates = motionWebPoints
+        .map((other, i) => ({ index: i, dist: Math.hypot(other.baseX - pt.baseX, other.baseY - pt.baseY) }))
+        .filter(entry => entry.index !== index)
+        .sort((a, b) => a.dist - b.dist)
+        .slice(0, 4);
+      candidates.forEach(candidate => {
+        const i1 = Math.min(index, candidate.index);
+        const i2 = Math.max(index, candidate.index);
+        const key = `${i1}-${i2}`;
+        if (!connectionSet.has(key)) {
+          connectionSet.add(key);
+          motionWebConnections.push([i1, i2]);
+        }
+      });
+    });
+  }
+
+  function rebuildMotionWeb() {
+    if (!interactiveText) return;
+    const container = motionWebPinned && motionWebDock ? motionWebDock : interactiveText;
+    const width = Math.max(1, Math.round(container.clientWidth || interactiveText.clientWidth));
+    const height = Math.max(1, Math.round(container.clientHeight || interactiveText.clientHeight));
+    if (width <= 0 || height <= 0) return;
+    if (!motionWebCanvas) {
+      motionWebCanvas = document.createElement('canvas');
+      motionWebCanvas.className = 'motion-web-canvas';
+      interactiveText.appendChild(motionWebCanvas);
+      attachMotionWebPointerHandlers(interactiveText);
+    }
+    motionWebCanvas.width = width;
+    motionWebCanvas.height = height;
+    motionWebCanvas.style.width = `${width}px`;
+    motionWebCanvas.style.height = `${height}px`;
+    motionWebCtx = motionWebCanvas.getContext('2d');
+    computeMotionWebData(width, height);
+    scheduleMotionWebDraw();
+    if (!motionWebPinned) {
+      motionWebCanvas.style.opacity = '0';
+    }
+  }
+
+  function setMotionWebPinned(pinned) {
+    if (motionWebPinned === pinned) return;
+    motionWebPinned = pinned;
+    if (!motionWebCanvas) return;
+    if (pinned && motionWebDock) {
+      motionWebDock.appendChild(motionWebCanvas);
+      motionWebDock.classList.add('visible');
+      motionWebCanvas.style.opacity = '1';
+      motionWebDock.setAttribute('aria-hidden', 'false');
+      attachMotionWebPointerHandlers(motionWebDock);
+      requestAnimationFrame(() => rebuildMotionWeb());
+    } else {
+      interactiveText.appendChild(motionWebCanvas);
+      if (motionWebDock) motionWebDock.classList.remove('visible');
+      if (motionWebDock) motionWebDock.setAttribute('aria-hidden', 'true');
+      attachMotionWebPointerHandlers(interactiveText);
+      requestAnimationFrame(() => rebuildMotionWeb());
+    }
+  }
+
+  function revealMotionText() {
+    wrapText(finalText, interactiveText);
+    interactiveText.classList.add('reveal-motion');
+    const previousOpacity = interactiveText.style.opacity;
+    interactiveText.style.opacity = '0';
+    requestAnimationFrame(() => {
+      interactiveText.style.opacity = '1';
+    });
+    setTimeout(() => {
+      interactiveText.classList.remove('reveal-motion');
+      interactiveText.style.opacity = previousOpacity;
+      interactiveText.classList.add('pixelate');
+      setTimeout(() => {
+        interactiveText.classList.remove('pixelate');
+        makeInteractive(interactiveText);
+        requestAnimationFrame(() => rebuildMotionWeb());
+      }, 500);
+    }, 900);
+  }
+
   wrapText(initial, interactiveText);
   typeText(interactiveText, initial, () => {
     setTimeout(() => {
@@ -2285,16 +2607,7 @@ document.addEventListener('DOMContentLoaded', () => {
           interactiveText.children[eraseIdx--].remove();
         } else {
           clearInterval(eraseTimer);
-          setTimeout(() => {
-            wrapText(finalText, interactiveText);
-            typeText(interactiveText, finalText, () => {
-              interactiveText.classList.add('pixelate');
-              setTimeout(() => {
-                interactiveText.classList.remove('pixelate');
-                makeInteractive(interactiveText);
-              }, 500);
-            });
-          }, 300);
+          setTimeout(revealMotionText, 300);
         }
       }, 50);
     }, 500);
@@ -2326,10 +2639,35 @@ document.addEventListener('DOMContentLoaded', () => {
       const lin = Math.min((scrollY - startFade) / (endFade - startFade), 1);
       fadeRatio = 1 - Math.pow(2, -20 * lin);
     }
-    [interactiveText, contactText, descriptionText].forEach(el => {
-      el.style.opacity = 1 - fadeRatio;
-      el.style.filter  = `blur(${fadeRatio * 10}px)`;
-    });
+    if (contactText) {
+      contactText.style.opacity = 1 - fadeRatio;
+      contactText.style.filter = `blur(${fadeRatio * 10}px)`;
+    }
+    if (descriptionText) {
+      descriptionText.style.opacity = 1 - fadeRatio;
+      descriptionText.style.filter = `blur(${fadeRatio * 10}px)`;
+    }
+
+    const webRatio = Math.max(0, Math.min((scrollY - startFade) / (endFade - startFade), 1));
+    if (interactiveText) {
+      const textOpacity = 1 - webRatio;
+      interactiveText.style.opacity = textOpacity;
+      const blurValue = Math.max(0, (fadeRatio * 10) - webRatio * 6);
+      interactiveText.style.filter = `blur(${blurValue}px)`;
+      if (motionWebCanvas && !motionWebPinned) {
+        motionWebCanvas.style.opacity = `${webRatio}`;
+      }
+      interactiveText.classList.toggle('web-mode', webRatio > 0.05 && !motionWebPinned);
+    }
+
+    motionWebJitterStrength = motionWebPinned ? 0.25 : webRatio;
+
+    if (footerParagraph) {
+      const rect = footerParagraph.getBoundingClientRect();
+      const shouldPin = rect.top < window.innerHeight * 0.75;
+      setMotionWebPinned(shouldPin);
+    }
+
   sequence.forEach((idx, i) => {
       const el    = icons[idx];
       const base  = baseOffsets[idx] || 0;
@@ -2496,6 +2834,8 @@ document.addEventListener('DOMContentLoaded', () => {
     Proficient working solo or within a creative team. I’m adept at developing clean and productive workflows and efficient production systems. Detail-focused, sharp eyed for the micro as well as the full picture. Experience working in difficult spaces, musical environnements and challenging deadlines. Passion for developping unique image treatment media and effects. Strong ability with both sober briefs and maximalist detail-heavy scenes. Capable of further developping client ideas by finding creative solutions to design challenges.
   </div>
 
+  <div id="motionWebDock" aria-hidden="true"></div>
+
   <div id="featureVideoShell">
     <div class="feature-media-panel feature-video-frame no-video">
       <video id="featureVideoPlayer" muted playsinline loop preload="metadata"></video>
@@ -2529,7 +2869,9 @@ document.addEventListener('DOMContentLoaded', () => {
     <img alt="Expanded project media" />
   </div>
 
-  <iframe src="orbit_inner.html" class="portfolio-orbit"></iframe>
+  <div class="portfolio-orbit-shell">
+    <iframe src="orbit_inner.html" class="portfolio-orbit"></iframe>
+  </div>
 
   <footer class="page-footer">
     <div class="real-footer" data-i18n="fontCredit">Ferrite Display Font by @willaggett</div>

--- a/mobile.html
+++ b/mobile.html
@@ -11,6 +11,52 @@
     #lang-toggle { position:fixed; top:10px; left:10px; border:3px solid blue; background:transparent; padding:5px 10px; cursor:pointer; z-index:1000; color:#1449ff; font-size:32px; font-weight:700; visibility:hidden; }
     .message { position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); width:90vw; text-align:center; font-size:2vw; color:#1449ff; text-transform:uppercase; line-height:1.6; padding:0 5vw; box-sizing:border-box; user-select:none; visibility:hidden; }
     .i18n-loading [data-i18n], .i18n-loading #lang-toggle, .i18n-loading .message { visibility:hidden; }
+
+    #audio-debug-panel {
+      position: fixed;
+      top: 12px;
+      left: 12px;
+      padding: 8px 12px;
+      background: rgba(0, 0, 0, 0.65);
+      color: #ffffff;
+      font-family: 'Ferrite Display', sans-serif;
+      font-size: 12px;
+      line-height: 1.4;
+      border-radius: 8px;
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      pointer-events: none;
+      z-index: 1000;
+      min-width: 160px;
+    }
+
+    #audio-debug-panel strong {
+      display: block;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 4px;
+    }
+
+    #audio-debug-panel ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    #audio-debug-panel li {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      font-size: 11px;
+      letter-spacing: 0.08em;
+    }
+
+    #audio-debug-panel .audio-debug-empty {
+      font-style: italic;
+      opacity: 0.75;
+    }
   </style>
 </head>
 <body>
@@ -30,6 +76,48 @@
       var mobileSource = null;
       var mobileReady = false;
 
+      var audioDebugPanel = document.createElement('div');
+      audioDebugPanel.id = 'audio-debug-panel';
+      var audioDebugTitle = document.createElement('strong');
+      audioDebugTitle.textContent = 'Audio Monitor';
+      var audioDebugEmpty = document.createElement('div');
+      audioDebugEmpty.className = 'audio-debug-empty';
+      var audioDebugList = document.createElement('ul');
+      audioDebugPanel.appendChild(audioDebugTitle);
+      audioDebugPanel.appendChild(audioDebugEmpty);
+      audioDebugPanel.appendChild(audioDebugList);
+      document.body.appendChild(audioDebugPanel);
+
+      function renderAudioDebug() {
+        if (!audioCtx) {
+          audioDebugEmpty.textContent = 'Audio unavailable';
+          audioDebugEmpty.style.display = 'block';
+          audioDebugList.style.display = 'none';
+          audioDebugList.innerHTML = '';
+          return;
+        }
+        if (mobileSource) {
+          audioDebugEmpty.style.display = 'none';
+          audioDebugList.style.display = 'flex';
+          audioDebugList.innerHTML = '';
+          var item = document.createElement('li');
+          var nameSpan = document.createElement('span');
+          nameSpan.textContent = 'mobile.wav';
+          var statusSpan = document.createElement('span');
+          statusSpan.textContent = 'looping';
+          item.appendChild(nameSpan);
+          item.appendChild(statusSpan);
+          audioDebugList.appendChild(item);
+        } else {
+          audioDebugEmpty.textContent = 'No audio active';
+          audioDebugEmpty.style.display = 'block';
+          audioDebugList.style.display = 'none';
+          audioDebugList.innerHTML = '';
+        }
+      }
+
+      renderAudioDebug();
+
       function startMobileBed() {
         if (!audioCtx || !mobileBuffer || !mobileReady || mobileSource) return;
         var source = audioCtx.createBufferSource();
@@ -38,6 +126,11 @@
         source.connect(audioCtx.destination);
         source.start();
         mobileSource = source;
+        source.onended = function() {
+          mobileSource = null;
+          renderAudioDebug();
+        };
+        renderAudioDebug();
       }
 
       function unlockMobileAudio() {
@@ -57,8 +150,15 @@
           .then(function(buffer) {
             mobileBuffer = buffer;
             startMobileBed();
+            renderAudioDebug();
           })
-          .catch(function(err) { console.warn('mobile audio failed', err); });
+          .catch(function(err) {
+            console.warn('mobile audio failed', err);
+            audioDebugEmpty.textContent = 'Audio failed to load';
+            audioDebugEmpty.style.display = 'block';
+            audioDebugList.style.display = 'none';
+            audioDebugList.innerHTML = '';
+          });
         ['pointerdown', 'touchstart', 'keydown'].forEach(function(evt) {
           window.addEventListener(evt, unlockMobileAudio, { once: true });
         });

--- a/mobile.html
+++ b/mobile.html
@@ -24,6 +24,45 @@
       var translations = {};
       var messageEl = document.querySelector('.message');
       var toggleEl = document.getElementById('lang-toggle');
+      var AudioCtx = window.AudioContext || window.webkitAudioContext;
+      var audioCtx = AudioCtx ? new AudioCtx() : null;
+      var mobileBuffer = null;
+      var mobileSource = null;
+      var mobileReady = false;
+
+      function startMobileBed() {
+        if (!audioCtx || !mobileBuffer || !mobileReady || mobileSource) return;
+        var source = audioCtx.createBufferSource();
+        source.buffer = mobileBuffer;
+        source.loop = true;
+        source.connect(audioCtx.destination);
+        source.start();
+        mobileSource = source;
+      }
+
+      function unlockMobileAudio() {
+        if (!audioCtx) return;
+        mobileReady = true;
+        if (audioCtx.state === 'suspended') {
+          audioCtx.resume().then(startMobileBed).catch(function(){});
+        } else {
+          startMobileBed();
+        }
+      }
+
+      if (audioCtx) {
+        fetch('SFX/mobile.wav')
+          .then(function(res) { return res.arrayBuffer(); })
+          .then(function(data) { return audioCtx.decodeAudioData(data); })
+          .then(function(buffer) {
+            mobileBuffer = buffer;
+            startMobileBed();
+          })
+          .catch(function(err) { console.warn('mobile audio failed', err); });
+        ['pointerdown', 'touchstart', 'keydown'].forEach(function(evt) {
+          window.addEventListener(evt, unlockMobileAudio, { once: true });
+        });
+      }
 
       // Helper to wrap text into spans
       function wrapText(el, text) {

--- a/mobile.html
+++ b/mobile.html
@@ -12,51 +12,6 @@
     .message { position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); width:90vw; text-align:center; font-size:2vw; color:#1449ff; text-transform:uppercase; line-height:1.6; padding:0 5vw; box-sizing:border-box; user-select:none; visibility:hidden; }
     .i18n-loading [data-i18n], .i18n-loading #lang-toggle, .i18n-loading .message { visibility:hidden; }
 
-    #audio-debug-panel {
-      position: fixed;
-      top: 12px;
-      left: 12px;
-      padding: 8px 12px;
-      background: rgba(0, 0, 0, 0.65);
-      color: #ffffff;
-      font-family: 'Ferrite Display', sans-serif;
-      font-size: 12px;
-      line-height: 1.4;
-      border-radius: 8px;
-      border: 1px solid rgba(255, 255, 255, 0.35);
-      pointer-events: none;
-      z-index: 1000;
-      min-width: 160px;
-    }
-
-    #audio-debug-panel strong {
-      display: block;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      margin-bottom: 4px;
-    }
-
-    #audio-debug-panel ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: flex;
-      flex-direction: column;
-      gap: 2px;
-    }
-
-    #audio-debug-panel li {
-      display: flex;
-      justify-content: space-between;
-      gap: 12px;
-      font-size: 11px;
-      letter-spacing: 0.08em;
-    }
-
-    #audio-debug-panel .audio-debug-empty {
-      font-style: italic;
-      opacity: 0.75;
-    }
   </style>
 </head>
 <body>
@@ -76,48 +31,6 @@
       var mobileSource = null;
       var mobileReady = false;
 
-      var audioDebugPanel = document.createElement('div');
-      audioDebugPanel.id = 'audio-debug-panel';
-      var audioDebugTitle = document.createElement('strong');
-      audioDebugTitle.textContent = 'Audio Monitor';
-      var audioDebugEmpty = document.createElement('div');
-      audioDebugEmpty.className = 'audio-debug-empty';
-      var audioDebugList = document.createElement('ul');
-      audioDebugPanel.appendChild(audioDebugTitle);
-      audioDebugPanel.appendChild(audioDebugEmpty);
-      audioDebugPanel.appendChild(audioDebugList);
-      document.body.appendChild(audioDebugPanel);
-
-      function renderAudioDebug() {
-        if (!audioCtx) {
-          audioDebugEmpty.textContent = 'Audio unavailable';
-          audioDebugEmpty.style.display = 'block';
-          audioDebugList.style.display = 'none';
-          audioDebugList.innerHTML = '';
-          return;
-        }
-        if (mobileSource) {
-          audioDebugEmpty.style.display = 'none';
-          audioDebugList.style.display = 'flex';
-          audioDebugList.innerHTML = '';
-          var item = document.createElement('li');
-          var nameSpan = document.createElement('span');
-          nameSpan.textContent = 'mobile.wav';
-          var statusSpan = document.createElement('span');
-          statusSpan.textContent = 'looping';
-          item.appendChild(nameSpan);
-          item.appendChild(statusSpan);
-          audioDebugList.appendChild(item);
-        } else {
-          audioDebugEmpty.textContent = 'No audio active';
-          audioDebugEmpty.style.display = 'block';
-          audioDebugList.style.display = 'none';
-          audioDebugList.innerHTML = '';
-        }
-      }
-
-      renderAudioDebug();
-
       function startMobileBed() {
         if (!audioCtx || !mobileBuffer || !mobileReady || mobileSource) return;
         var source = audioCtx.createBufferSource();
@@ -128,9 +41,7 @@
         mobileSource = source;
         source.onended = function() {
           mobileSource = null;
-          renderAudioDebug();
         };
-        renderAudioDebug();
       }
 
       function unlockMobileAudio() {
@@ -150,14 +61,9 @@
           .then(function(buffer) {
             mobileBuffer = buffer;
             startMobileBed();
-            renderAudioDebug();
           })
           .catch(function(err) {
             console.warn('mobile audio failed', err);
-            audioDebugEmpty.textContent = 'Audio failed to load';
-            audioDebugEmpty.style.display = 'block';
-            audioDebugList.style.display = 'none';
-            audioDebugList.innerHTML = '';
           });
         ['pointerdown', 'touchstart', 'keydown'].forEach(function(evt) {
           window.addEventListener(evt, unlockMobileAudio, { once: true });

--- a/orbit_inner.html
+++ b/orbit_inner.html
@@ -21,7 +21,6 @@
       height: 100%;
       background: transparent;
       overflow: hidden;
-      cursor: none;
     }
     #sceneWrap {
       position: fixed;
@@ -184,24 +183,9 @@
       display: block;
     }
 
-    #cursorDot {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 16px;
-      height: 16px;
-      border-radius: 50%;
-      background: var(--accent-color, #1449ff);
-      pointer-events: none;
-      transform: translate(-50%, -50%) scale(1);
-      opacity: 0;
-      transition: opacity 0.18s ease, transform 0.18s ease, background var(--theme-transition, 0.45s);
-      z-index: 10;
-    }
   </style>
 </head>
 <body>
-  <div id="cursorDot" aria-hidden="true"></div>
   <div id="sceneWrap">
     <canvas id="bgCanvas"></canvas>
     <canvas id="fgCanvas"></canvas>
@@ -474,7 +458,6 @@
       positionShowcasePanel();
       if (gifPreview) {
         gifPreview.style.setProperty('--accent-color', accentColor);
-        if (cursorDot) cursorDot.style.backgroundColor = accentColor;
       }
     }
 
@@ -549,61 +532,9 @@
     let lastCardUpdate = performance.now();
     let activeDragState = null;
 
-    const cursorDot = document.getElementById('cursorDot');
-    let cursorVisible = false;
-    let cursorScale = 1;
-    let cursorX = window.innerWidth * 0.5;
-    let cursorY = window.innerHeight * 0.5;
-
-    function updateCursor(scale = cursorScale) {
-      if (!cursorDot) return;
-      cursorScale = scale;
-      cursorDot.style.transform = `translate(${cursorX}px, ${cursorY}px) translate(-50%, -50%) scale(${cursorScale})`;
-    }
-
-    function showCursor() {
-      if (!cursorDot) return;
-      cursorVisible = true;
-      cursorDot.style.opacity = '1';
-    }
-
-    function hideCursor() {
-      if (!cursorDot) return;
-      cursorVisible = false;
-      cursorDot.style.opacity = '0';
-    }
-
-    if (cursorDot) {
-      cursorDot.style.backgroundColor = accentColor;
-      window.addEventListener('pointermove', event => {
-        cursorX = event.clientX;
-        cursorY = event.clientY;
-        updateCursor(cursorScale);
-        showCursor();
-        moveCardDrag(event);
-      });
-      window.addEventListener('pointerdown', event => {
-        cursorX = event.clientX;
-        cursorY = event.clientY;
-        updateCursor(0.75);
-        showCursor();
-      });
-      window.addEventListener('pointerup', event => {
-        cursorX = event.clientX;
-        cursorY = event.clientY;
-        updateCursor(1);
-        showCursor();
-        endCardDrag(event);
-      });
-      window.addEventListener('pointerleave', event => {
-        hideCursor();
-        endCardDrag(event);
-      });
-      window.addEventListener('pointercancel', event => {
-        endCardDrag(event);
-        hideCursor();
-      });
-    }
+    window.addEventListener('pointermove', moveCardDrag);
+    window.addEventListener('pointerup', endCardDrag);
+    window.addEventListener('pointercancel', endCardDrag);
 
     function positionCardState(state) {
       if (!state || !state.el) return;
@@ -716,10 +647,6 @@
         state.el.classList.add('dragging');
         try { state.el.setPointerCapture(event.pointerId); } catch (err) {}
       }
-      cursorX = event.clientX;
-      cursorY = event.clientY;
-      updateCursor(0.75);
-      showCursor();
     }
 
     function moveCardDrag(event) {
@@ -762,12 +689,7 @@
         state.el.classList.remove('dragging');
       }
       activeDragState = null;
-      if (event) {
-        cursorX = event.clientX;
-        cursorY = event.clientY;
-        updateCursor(1);
-        showCursor();
-      }
+      void event;
     }
 
     function refreshCardAccent() {
@@ -775,9 +697,6 @@
         state.el.style.borderColor = accentColor;
         state.el.style.backgroundColor = colorWithAlpha(accentColor, 0.12);
       });
-      if (cursorDot) {
-        cursorDot.style.backgroundColor = accentColor;
-      }
     }
 
     function updateCardTargets(state) {
@@ -1272,6 +1191,7 @@
       });
       letters.forEach((out, i) => {
         out.addEventListener('mouseenter', () => {
+          notifySound('interactive-text');
           const wH = baseWidths[i] * S;
           const wN = (i > 0 ? baseWidths[i - 1] * S : 0) + (i < letters.length - 1 ? baseWidths[i + 1] * S : 0);
           const wO = Math.max(totalW - wH - wN, 0.0001);
@@ -1309,6 +1229,15 @@
     function postSelectionToParent(payload) {
       try {
         parent.postMessage({ showcaseSelection: payload }, '*');
+      } catch (error) {
+        /* ignore cross-origin issues */
+      }
+    }
+
+    function notifySound(eventName) {
+      if (!eventName) return;
+      try {
+        parent.postMessage({ soundEvent: eventName }, '*');
       } catch (error) {
         /* ignore cross-origin issues */
       }
@@ -1586,6 +1515,7 @@
       const f = hits[0].object.parent;
       const idx = folders.indexOf(f);
       if (idx === -1) return;
+      notifySound('folder-click');
       if (mode === 'orbit') {
         selectedIndex = idx;
         enterAlign();
@@ -1689,7 +1619,12 @@
         raycaster.setFromCamera(mouse, camera);
         const hoverHits = raycaster.intersectObjects(folders.map(f => f.userData.front));
         folders.forEach(f => {
-          f.userData.hovered = hoverHits.some(h => h.object === f.userData.front);
+          const wasHovered = !!f.userData.hovered;
+          const isHovered = hoverHits.some(h => h.object === f.userData.front);
+          f.userData.hovered = isHovered;
+          if (!wasHovered && isHovered) {
+            notifySound('folder-hover');
+          }
         });
         const len = folders.length || 1;
         let allComplete = true;
@@ -1751,7 +1686,12 @@
         raycaster.setFromCamera(mouse, camera);
         const hoverHits = raycaster.intersectObjects(folders.map(f => f.userData.front));
         folders.forEach(f => {
-          f.userData.hovered = hoverHits.some(h => h.object === f.userData.front);
+          const wasHovered = !!f.userData.hovered;
+          const isHovered = hoverHits.some(h => h.object === f.userData.front);
+          f.userData.hovered = isHovered;
+          if (!wasHovered && isHovered) {
+            notifySound('folder-hover');
+          }
         });
         const accel = Math.hypot(targetMouse.x - currentMouse.x, targetMouse.y - currentMouse.y);
         if (magnetized && accel > 2) magnetized = null;
@@ -1874,7 +1814,6 @@
         labelsContainer.style.setProperty('--accent-color', accentColor);
         if (showcasePanel) showcasePanel.style.setProperty('--accent-color', accentColor);
         if (gifPreview) gifPreview.style.setProperty('--accent-color', accentColor);
-        if (cursorDot) cursorDot.style.backgroundColor = accentColor;
         refreshCardAccent();
       }
       if (typeof e.data.closeGrid === 'boolean' && e.data.closeGrid) {


### PR DESCRIPTION
## Summary
- remove the custom cursor implementation and make the global background color swap in sync with the theme
- add a web audio controller that maps the provided SFX to desktop interactions and manages the constant light/dark/folder beds
- emit sound events from the orbit iframe and loop the mobile-only audio bed on the mobile landing page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da9b8d3d7c8324aac717ac1d7153f9