### PR TITLE
Add audio toggle and improve showcase media display

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,65 +58,6 @@
       visibility: hidden;
     }
 
-    #audio-debug-panel {
-      position: fixed;
-      top: calc(12px + 60px + 20px);
-      left: 12px;
-      padding: 10px 12px;
-      background: rgba(0, 0, 0, 0.65);
-      color: #ffffff;
-      font-family: 'Outfit', sans-serif;
-      font-size: 12px;
-      line-height: 1.4;
-      border-radius: 8px;
-      border: 1px solid rgba(255, 255, 255, 0.35);
-      z-index: 1000;
-      pointer-events: none;
-      min-width: 180px;
-      white-space: pre-line;
-      transition: background-color var(--theme-transition) ease, color var(--theme-transition) ease, border-color var(--theme-transition) ease;
-    }
-
-    body.dark-mode #audio-debug-panel {
-      background: rgba(13, 15, 20, 0.78);
-      border-color: rgba(215, 43, 43, 0.45);
-      color: #f4f4f4;
-    }
-
-    #audio-debug-panel strong {
-      display: block;
-      font-weight: 600;
-      letter-spacing: 0.05em;
-      margin-bottom: 4px;
-      text-transform: uppercase;
-    }
-
-    #audio-debug-panel ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: flex;
-      flex-direction: column;
-      gap: 2px;
-    }
-
-    #audio-debug-panel li {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 16px;
-      font-family: 'Ferrite Display', sans-serif;
-      font-size: 11px;
-      letter-spacing: 0.08em;
-    }
-
-    #audio-debug-panel .audio-debug-empty {
-      opacity: 0.7;
-      font-style: italic;
-      font-family: 'Outfit', sans-serif;
-      letter-spacing: 0.04em;
-    }
-
     /* Language toggle button styling */
     #lang-toggle {
       position: fixed;
@@ -984,7 +925,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const SOUND_FILES = {
     click: 'click.wav',
     scroll: 'scroll.wav',
-    scrollTabs: 'scroll_tabs.wav',
     scrollAuto: 'scroll_auto.wav',
     interactiveText: 'interactive_text.wav',
     contactHover: 'contact_hover.wav',
@@ -997,6 +937,12 @@ document.addEventListener('DOMContentLoaded', () => {
     darkBed: 'dark_constant.wav',
     folderBed: 'folder_constant.wav'
   };
+
+  const CONSTANT_SOUNDS = new Set([
+    SOUND_FILES.lightBed,
+    SOUND_FILES.darkBed,
+    SOUND_FILES.folderBed
+  ]);
 
   const SOUND_COOLDOWNS = {
     [SOUND_FILES.click]: 500,
@@ -1034,6 +980,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const buffers = new Map();
     const loading = new Map();
     const loops = new Map();
+    const clips = new Map();
     const cooldowns = new Map();
     const activeSounds = new Map();
     const debugListeners = new Set();
@@ -1158,6 +1105,38 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
 
+    function fadeClipEntry(name, entry, fadeSeconds = 0.8) {
+      if (!entry) return;
+      const now = ctx.currentTime;
+      const duration = Math.max(0.05, fadeSeconds || 0.05);
+      entry.gain.gain.cancelScheduledValues(now);
+      entry.gain.gain.setValueAtTime(entry.gain.gain.value, now);
+      entry.gain.gain.linearRampToValueAtTime(0.0001, now + duration);
+      markSoundFading(name, duration);
+      clips.delete(name);
+      try {
+        entry.source.stop(now + duration + 0.1);
+      } catch (error) {
+        try { entry.source.stop(); } catch (_) {}
+      }
+    }
+
+    function fadeOtherSounds(currentName, fadeSeconds = 0.8) {
+      const duration = Math.max(0.05, fadeSeconds || 0.05);
+      const loopsToStop = [];
+      loops.forEach((_, loopName) => {
+        if (loopName === currentName) return;
+        if (CONSTANT_SOUNDS.has(loopName)) return;
+        loopsToStop.push(loopName);
+      });
+      loopsToStop.forEach(loopName => stopLoop(loopName, duration));
+      clips.forEach((entry, clipName) => {
+        if (clipName === currentName) return;
+        if (CONSTANT_SOUNDS.has(clipName)) return;
+        fadeClipEntry(clipName, entry, duration);
+      });
+    }
+
     function setMasterMuted(muted, ramp = 0.2) {
       const duration = Math.max(0.05, typeof ramp === 'number' ? ramp : 0.2);
       const target = muted ? 0.0001 : 1;
@@ -1176,12 +1155,16 @@ document.addEventListener('DOMContentLoaded', () => {
         playbackRate = 1,
         duration = null,
         cooldown = DEFAULT_COOLDOWN,
-        allowOverlap = false
+        allowOverlap = false,
+        duckOthersFade = 0.8
       } = options;
       if (!allowOverlap && isSoundActive(name)) return;
       if (!allowOverlap && isCoolingDown(name, cooldown)) return;
       markCooldown(name, cooldown);
       unlock();
+      if (!CONSTANT_SOUNDS.has(name)) {
+        fadeOtherSounds(name, duckOthersFade);
+      }
       loadBuffer(name).then(buffer => {
         if (!buffer) return;
         const now = ctx.currentTime;
@@ -1194,8 +1177,12 @@ document.addEventListener('DOMContentLoaded', () => {
         source.connect(gain);
         gain.connect(master);
         source.start(now);
+        clips.set(name, { source, gain });
         setActiveSound(name, { loop: false });
-        source.onended = () => clearActiveSound(name);
+        source.onended = () => {
+          clips.delete(name);
+          clearActiveSound(name);
+        };
         const safeVolume = Math.max(0, volume);
         if (fadeIn > 0) {
           gain.gain.linearRampToValueAtTime(safeVolume, now + fadeIn);
@@ -1228,6 +1215,9 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       markCooldown(name, cooldownMs);
       unlock();
+      if (!CONSTANT_SOUNDS.has(name)) {
+        fadeOtherSounds(name, options.duckOthersFade ?? 0.8);
+      }
 
       return loadBuffer(name).then(buffer => {
         if (!buffer) return null;
@@ -1319,75 +1309,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const soundController = createSoundController();
   const audioSupported = Boolean(soundController && soundController.supported);
-  const audioDebugPanel = document.createElement('div');
-  audioDebugPanel.id = 'audio-debug-panel';
-  const audioDebugTitle = document.createElement('strong');
-  audioDebugTitle.textContent = 'Audio Monitor';
-  const audioDebugEmpty = document.createElement('div');
-  audioDebugEmpty.className = 'audio-debug-empty';
-  const audioDebugList = document.createElement('ul');
-  audioDebugPanel.append(audioDebugTitle, audioDebugEmpty, audioDebugList);
-
-  function updateAudioDebugPanel(sounds = []) {
-    if (!audioSupported) {
-      audioDebugEmpty.textContent = 'Audio unavailable';
-      audioDebugEmpty.style.display = 'block';
-      audioDebugList.style.display = 'none';
-      audioDebugList.innerHTML = '';
-      return;
-    }
-    const entries = Array.isArray(sounds)
-      ? sounds.slice().sort((a, b) => a.name.localeCompare(b.name))
-      : [];
-    if (!entries.length) {
-      audioDebugEmpty.textContent = 'No audio active';
-      audioDebugEmpty.style.display = 'block';
-      audioDebugList.style.display = 'none';
-      audioDebugList.innerHTML = '';
-      return;
-    }
-    audioDebugEmpty.style.display = 'none';
-    audioDebugList.style.display = 'flex';
-    audioDebugList.innerHTML = '';
-    entries.forEach(sound => {
-      const item = document.createElement('li');
-      const nameSpan = document.createElement('span');
-      nameSpan.textContent = sound.name;
-      const statusSpan = document.createElement('span');
-      let statusText = sound.loop ? 'looping' : 'one-shot';
-      if (!sound.loop && sound.count && sound.count > 1) {
-        statusText += ` ×${sound.count}`;
-      }
-      if (sound.fading) {
-        statusText += ' (fading)';
-      }
-      statusSpan.textContent = statusText;
-      item.append(nameSpan, statusSpan);
-      audioDebugList.appendChild(item);
-    });
-  }
-
-  const initialActive = typeof soundController.getActiveSounds === 'function'
-    ? soundController.getActiveSounds()
-    : [];
-  updateAudioDebugPanel(initialActive);
-  if (typeof soundController.onActiveChange === 'function') {
-    soundController.onActiveChange(updateAudioDebugPanel);
-  }
-
-  function attachAudioDebugPanel() {
-    if (!document.body || audioDebugPanel.isConnected) return;
-    document.body.appendChild(audioDebugPanel);
-    updateAudioDebugPanel(typeof soundController.getActiveSounds === 'function'
-      ? soundController.getActiveSounds()
-      : initialActive);
-  }
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', attachAudioDebugPanel, { once: true });
-  } else {
-    attachAudioDebugPanel();
-  }
   const SOUND_PREF_KEY = 'ms-sound-enabled';
   let interactiveAudioEnabled = true;
   try {
@@ -1405,7 +1326,6 @@ document.addEventListener('DOMContentLoaded', () => {
   let autoScrollActive = false;
   let autoScrollTimer = null;
   let scrollStopTimer = null;
-  let scrollTabsStopTimer = null;
   let lastScrollY = window.scrollY || 0;
   let lastScrollTime = performance.now();
 
@@ -1453,7 +1373,6 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     } else {
       soundController.stopLoop(SOUND_FILES.scroll, 0.5);
-      soundController.stopLoop(SOUND_FILES.scrollTabs, 0.5);
       soundController.stopLoop(SOUND_FILES.idHold, 0.5);
       soundController.stopLoop(SOUND_FILES.folderBed, 0.5);
       soundController.stopLoop(SOUND_FILES.lightBed, 0.5);
@@ -1477,13 +1396,15 @@ document.addEventListener('DOMContentLoaded', () => {
     if (audioPrimed) return true;
     audioPrimed = true;
     if (!introPlayed) {
+      const INTRO_DURATION = 10;
       soundController.playClip(SOUND_FILES.intro, {
-        volume: 0.55,
-        duration: 7,
-        fadeIn: 1,
-        fadeOut: 3,
+        volume: 0.5,
+        duration: INTRO_DURATION,
+        fadeIn: 1.4,
+        fadeOut: 4.5,
         cooldown: 0,
-        allowOverlap: true
+        allowOverlap: true,
+        duckOthersFade: 1
       });
       introPlayed = true;
     }
@@ -1492,7 +1413,7 @@ document.addEventListener('DOMContentLoaded', () => {
       soundController.stopLoop(SOUND_FILES.lightBed, 5);
       soundController.stopLoop(SOUND_FILES.darkBed, 5);
     } else {
-      updateThemeConstant(true);
+      updateThemeConstant(true, 10);
     }
     return true;
   }
@@ -1509,11 +1430,11 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function triggerInteractiveTextSound() {
-    playEffect(SOUND_FILES.interactiveText, { volume: 0.52 });
+    playEffect(SOUND_FILES.interactiveText, { volume: 0.36, fadeOut: 2.2, duckOthersFade: 1 });
   }
 
   function triggerContactHoverSound() {
-    playEffect(SOUND_FILES.contactHover, { volume: 0.58 });
+    playEffect(SOUND_FILES.contactHover, { volume: 0.42, fadeOut: 2.4, duckOthersFade: 1 });
   }
 
   function triggerAutoScrollSound(duration) {
@@ -1538,6 +1459,11 @@ document.addEventListener('DOMContentLoaded', () => {
     soundController.stopLoop(SOUND_FILES.idHold, 3);
   }
 
+  if (typeof window !== 'undefined') {
+    window.startIdHoldSound = startIdHoldSound;
+    window.stopIdHoldSound = stopIdHoldSound;
+  }
+
   function setAutoScrollState(active, duration = 0) {
     autoScrollActive = active;
     if (autoScrollTimer) {
@@ -1546,8 +1472,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if (active) {
       if (audioSupported) {
-        soundController.stopLoop(SOUND_FILES.scroll, 0.6);
-        soundController.stopLoop(SOUND_FILES.scrollTabs, 0.6);
+        soundController.stopLoop(SOUND_FILES.scroll, 1);
       }
       if (duration > 0) {
         autoScrollTimer = window.setTimeout(() => {
@@ -1558,9 +1483,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function updateThemeConstant(immediate = false) {
+  function updateThemeConstant(immediate = false, fadeOverride = null) {
     if (!audioSupported || !audioPrimed || folderZoneActive || !interactiveAudioEnabled) return;
-    const fade = immediate ? 0.6 : 1.5;
+    const fade = (typeof fadeOverride === 'number' && Number.isFinite(fadeOverride))
+      ? Math.max(0.05, fadeOverride)
+      : (immediate ? 0.6 : 1.5);
     if (currentTheme === 'dark') {
       soundController.ensureLoop(SOUND_FILES.darkBed, { volume: 0.16, fadeIn: fade, cooldown: 0 });
       soundController.stopLoop(SOUND_FILES.lightBed, fade);
@@ -1588,9 +1515,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!audioSupported || !interactiveAudioEnabled) return;
     switch (name) {
       case 'folder-hover':
+        if (!folderZoneActive) return;
         playEffect(SOUND_FILES.folderHover, { volume: 0.5 });
         break;
       case 'folder-click':
+        if (!folderZoneActive) return;
         playEffect(SOUND_FILES.folderClick, { volume: 0.64 });
         break;
       case 'interactive-text':
@@ -1605,7 +1534,6 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!audioSupported) return;
     if (!interactiveAudioEnabled) {
       soundController.stopLoop(SOUND_FILES.scroll, 0.4);
-      soundController.stopLoop(SOUND_FILES.scrollTabs, 0.4);
       return;
     }
     const now = performance.now();
@@ -1617,46 +1545,30 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (autoScrollActive) {
       if (scrollStopTimer) { clearTimeout(scrollStopTimer); scrollStopTimer = null; }
-      if (scrollTabsStopTimer) { clearTimeout(scrollTabsStopTimer); scrollTabsStopTimer = null; }
       return;
     }
+    const distance = Math.abs(delta);
+    const pxPerSec = distance / dt * 1000;
+    let intensity = Math.min(pxPerSec / 1400, 1);
+    if (distance < 0.5 || intensity < 0.0001) {
+      intensity = 0;
+    }
+    const active = intensity > 0.045;
 
-    const pxPerSec = Math.abs(delta) / dt * 1000;
-    const intensity = Math.min(pxPerSec / 1400, 1);
-
-    if (intensity > 0.015) {
+    if (active) {
       ensureSoundReady();
-      const volume = 0.16 + intensity * 0.36;
-      soundController.ensureLoop(SOUND_FILES.scroll, { volume, fadeIn: 0.6, cooldown: 0 });
-      soundController.setLoopVolume(SOUND_FILES.scroll, volume, 0.25);
-      if (scrollStopTimer) clearTimeout(scrollStopTimer);
-      scrollStopTimer = window.setTimeout(() => {
-        soundController.stopLoop(SOUND_FILES.scroll, 1.6);
+      const volume = 0.02 + intensity * 0.14;
+      soundController.ensureLoop(SOUND_FILES.scroll, { volume, fadeIn: 0.4, cooldown: 0 });
+      soundController.setLoopVolume(SOUND_FILES.scroll, volume, 0.2);
+      if (scrollStopTimer) {
+        clearTimeout(scrollStopTimer);
         scrollStopTimer = null;
-      }, 220);
+      }
     } else if (!scrollStopTimer && soundController.isLoopActive(SOUND_FILES.scroll)) {
       scrollStopTimer = window.setTimeout(() => {
-        soundController.stopLoop(SOUND_FILES.scroll, 1.6);
+        soundController.stopLoop(SOUND_FILES.scroll, 1);
         scrollStopTimer = null;
-      }, 220);
-    }
-
-    const inTabsRange = currentY >= window.innerHeight && currentY <= window.innerHeight * 4;
-    if (intensity > 0.02 && inTabsRange) {
-      ensureSoundReady();
-      const tabVolume = 0.12 + intensity * 0.18;
-      soundController.ensureLoop(SOUND_FILES.scrollTabs, { volume: tabVolume, fadeIn: 0.8, cooldown: 0 });
-      soundController.setLoopVolume(SOUND_FILES.scrollTabs, tabVolume, 0.3);
-      if (scrollTabsStopTimer) clearTimeout(scrollTabsStopTimer);
-      scrollTabsStopTimer = window.setTimeout(() => {
-        soundController.stopLoop(SOUND_FILES.scrollTabs, 2);
-        scrollTabsStopTimer = null;
-      }, 260);
-    } else if (!scrollTabsStopTimer && soundController.isLoopActive(SOUND_FILES.scrollTabs)) {
-      scrollTabsStopTimer = window.setTimeout(() => {
-        soundController.stopLoop(SOUND_FILES.scrollTabs, 2);
-        scrollTabsStopTimer = null;
-      }, 200);
+      }, 80);
     }
   }
 
@@ -1672,7 +1584,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (event.button !== undefined && event.button !== 0) return;
     ensureSoundReady();
     if (audioSupported) {
-      playEffect(SOUND_FILES.click, { volume: 0.62 });
+      playEffect(SOUND_FILES.click, { volume: 0.62, fadeIn: 0.05, fadeOut: 2, duckOthersFade: 1 });
     }
   }, { passive: true });
 
@@ -2708,9 +2620,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const hit=raycaster.intersectObjects(cardMeshes,false);
         if(!hit.length) return;
         isDown=true; isUp=false; tDownStart=performance.now(); prevDown=0; maskCtx.fillStyle='black'; maskCtx.fillRect(0,0,maskSize,maskSize); maskTexture.needsUpdate=true;
-        startIdHoldSound();
+        if (typeof window.startIdHoldSound === 'function') {
+          window.startIdHoldSound();
+        }
       });
-      window.addEventListener('mouseup',()=>{ if(isDown){ isDown=false; isUp=true; tUpStart=performance.now(); prevUp=0; } stopIdHoldSound(); });
+      window.addEventListener('mouseup',()=>{ if(isDown){ isDown=false; isUp=true; tUpStart=performance.now(); prevUp=0; } if(typeof window.stopIdHoldSound==='function'){ window.stopIdHoldSound(); } });
       const mouse=new THREE.Vector2();
       window.addEventListener('mousemove',e=>{
         const rect=container.getBoundingClientRect();

--- a/index.html
+++ b/index.html
@@ -1036,6 +1036,10 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  if (typeof window !== 'undefined') {
+    window.queuePortfolioMediaPreload = queuePortfolioMediaPreload;
+  }
+
   const SOUND_FILES = {
     click: 'click.wav',
     scroll: 'scroll.wav',
@@ -2995,7 +2999,23 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     applyPortfolio(portfolioManifest);
     sendPortfolio();
-    queuePortfolioMediaPreload(portfolioManifest);
+    const runPreload = () => {
+      if (typeof window.queuePortfolioMediaPreload === 'function') {
+        try {
+          window.queuePortfolioMediaPreload(portfolioManifest);
+        } catch (error) {
+          console.warn('Failed to queue portfolio preloads', error);
+        }
+      }
+    };
+
+    if (typeof window.queuePortfolioMediaPreload === 'function') {
+      runPreload();
+    } else if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', runPreload, { once: true });
+    } else {
+      runPreload();
+    }
   }
 
   if (orbitIframe) orbitIframe.addEventListener('load', sendPortfolio);

--- a/index.html
+++ b/index.html
@@ -956,7 +956,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  function collectMediaSources(entry) {
+  const collectMediaSources = window.collectMediaSources || function collectMediaSources(entry) {
     const sources = [];
     const seen = new Set();
     const addSource = value => {
@@ -1021,6 +1021,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     return sources;
+  };
+
+  if (typeof window !== 'undefined') {
+    window.collectMediaSources = collectMediaSources;
   }
 
   function extractPrimaryMediaSource(entry) {

--- a/index.html
+++ b/index.html
@@ -58,6 +58,65 @@
       visibility: hidden;
     }
 
+    #audio-debug-panel {
+      position: fixed;
+      top: calc(12px + 60px + 20px);
+      left: 12px;
+      padding: 10px 12px;
+      background: rgba(0, 0, 0, 0.65);
+      color: #ffffff;
+      font-family: 'Outfit', sans-serif;
+      font-size: 12px;
+      line-height: 1.4;
+      border-radius: 8px;
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      z-index: 1000;
+      pointer-events: none;
+      min-width: 180px;
+      white-space: pre-line;
+      transition: background-color var(--theme-transition) ease, color var(--theme-transition) ease, border-color var(--theme-transition) ease;
+    }
+
+    body.dark-mode #audio-debug-panel {
+      background: rgba(13, 15, 20, 0.78);
+      border-color: rgba(215, 43, 43, 0.45);
+      color: #f4f4f4;
+    }
+
+    #audio-debug-panel strong {
+      display: block;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      margin-bottom: 4px;
+      text-transform: uppercase;
+    }
+
+    #audio-debug-panel ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    #audio-debug-panel li {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 16px;
+      font-family: 'Ferrite Display', sans-serif;
+      font-size: 11px;
+      letter-spacing: 0.08em;
+    }
+
+    #audio-debug-panel .audio-debug-empty {
+      opacity: 0.7;
+      font-style: italic;
+      font-family: 'Outfit', sans-serif;
+      letter-spacing: 0.04em;
+    }
+
     /* Language toggle button styling */
     #lang-toggle {
       position: fixed;
@@ -1260,6 +1319,75 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const soundController = createSoundController();
   const audioSupported = Boolean(soundController && soundController.supported);
+  const audioDebugPanel = document.createElement('div');
+  audioDebugPanel.id = 'audio-debug-panel';
+  const audioDebugTitle = document.createElement('strong');
+  audioDebugTitle.textContent = 'Audio Monitor';
+  const audioDebugEmpty = document.createElement('div');
+  audioDebugEmpty.className = 'audio-debug-empty';
+  const audioDebugList = document.createElement('ul');
+  audioDebugPanel.append(audioDebugTitle, audioDebugEmpty, audioDebugList);
+
+  function updateAudioDebugPanel(sounds = []) {
+    if (!audioSupported) {
+      audioDebugEmpty.textContent = 'Audio unavailable';
+      audioDebugEmpty.style.display = 'block';
+      audioDebugList.style.display = 'none';
+      audioDebugList.innerHTML = '';
+      return;
+    }
+    const entries = Array.isArray(sounds)
+      ? sounds.slice().sort((a, b) => a.name.localeCompare(b.name))
+      : [];
+    if (!entries.length) {
+      audioDebugEmpty.textContent = 'No audio active';
+      audioDebugEmpty.style.display = 'block';
+      audioDebugList.style.display = 'none';
+      audioDebugList.innerHTML = '';
+      return;
+    }
+    audioDebugEmpty.style.display = 'none';
+    audioDebugList.style.display = 'flex';
+    audioDebugList.innerHTML = '';
+    entries.forEach(sound => {
+      const item = document.createElement('li');
+      const nameSpan = document.createElement('span');
+      nameSpan.textContent = sound.name;
+      const statusSpan = document.createElement('span');
+      let statusText = sound.loop ? 'looping' : 'one-shot';
+      if (!sound.loop && sound.count && sound.count > 1) {
+        statusText += ` ×${sound.count}`;
+      }
+      if (sound.fading) {
+        statusText += ' (fading)';
+      }
+      statusSpan.textContent = statusText;
+      item.append(nameSpan, statusSpan);
+      audioDebugList.appendChild(item);
+    });
+  }
+
+  const initialActive = typeof soundController.getActiveSounds === 'function'
+    ? soundController.getActiveSounds()
+    : [];
+  updateAudioDebugPanel(initialActive);
+  if (typeof soundController.onActiveChange === 'function') {
+    soundController.onActiveChange(updateAudioDebugPanel);
+  }
+
+  function attachAudioDebugPanel() {
+    if (!document.body || audioDebugPanel.isConnected) return;
+    document.body.appendChild(audioDebugPanel);
+    updateAudioDebugPanel(typeof soundController.getActiveSounds === 'function'
+      ? soundController.getActiveSounds()
+      : initialActive);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', attachAudioDebugPanel, { once: true });
+  } else {
+    attachAudioDebugPanel();
+  }
   const SOUND_PREF_KEY = 'ms-sound-enabled';
   let interactiveAudioEnabled = true;
   try {

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
       --text-primary: #1449ff;
       --topo-light: #ffffff;
       --theme-transition: 1s;
+      --link-glow-color: rgba(20, 73, 255, 0.28);
     }
 
     body.dark-mode {
@@ -35,6 +36,7 @@
       --bg-alt: #1d1f24;
       --text-primary: #d72b2b;
       --topo-light: #1d1f24;
+      --link-glow-color: rgba(215, 43, 43, 0.32);
     }
 
     html, body {
@@ -596,13 +598,14 @@
       color: var(--accent);
       text-decoration: none;
       text-transform: uppercase;
+      text-shadow: 0 0 10px var(--link-glow-color);
       transition: text-shadow 0.25s ease;
     }
 
     .feature-link-item:hover,
     .feature-link-item:focus {
       color: var(--accent);
-      text-shadow: 0 0 18px rgba(255, 255, 255, 0.45);
+      text-shadow: 0 0 22px var(--link-glow-color);
     }
 
     .feature-image-overlay {
@@ -818,10 +821,10 @@
     <div class="folder-icon" data-index="0">
       <svg viewBox="0 0 100 70" xmlns="http://www.w3.org/2000/svg">
         <path d="M4,14 L4,6 A2,2 0 0 1 6,4 H42 Q44,4 46,6 L52,12 Q54,14 56,14 H92 Q96,14 96,18 V60 Q96,64 92,64 H8 Q4,64 4,60 Z" fill="var(--bg-main)" stroke="currentColor" stroke-width="1" stroke-linejoin="round" stroke-linecap="round"/>
-        <text x="8" y="14" data-i18n="photoTitle">PHOTO</text>
+        <text x="8" y="14" data-i18n="designTitle">DESIGN</text>
       </svg>
-      <div class="folder-box" data-i18n="photoContent">
-        CAPTURING AUTHENTIC AND SHARP SCENES IN A VIVID AND RAW STATE, IN SPONTANEOUS OR PREPARED ENVIRONMENTS. MY FOCUS IS ON STAND-OUT DETAIL, WITH AN EYE FOR ELEMENTS WHICH FUNDAMENTALLY COMMUNICATE THE REQUIRED MESSAGE.
+      <div class="folder-box" data-i18n="designContent">
+        WHETHER IT BE LOGOS OR FULL-ON REBRANDING, OVERLAY ELEMENTS FOR VISUALS OR COMPLETE MOTION DESIGNS, FLYERS OR OUTRIGHT MAGAZINES, I AM ABLE TO PROVIDE THE GRAPHICS THAT REPRESENT YOUR CREATIVE IDEAS.
       </div>
     </div>
     <div class="folder-icon" data-index="1">
@@ -836,22 +839,13 @@
     <div class="folder-icon" data-index="2">
       <svg viewBox="0 0 100 70" xmlns="http://www.w3.org/2000/svg">
         <path d="M4,14 L4,6 A2,2 0 0 1 6,4 H42 Q44,4 46,6 L52,12 Q54,14 56,14 H92 Q96,14 96,18 V60 Q96,64 92,64 H8 Q4,64 4,60 Z" fill="var(--bg-main)" stroke="currentColor" stroke-width="1" stroke-linejoin="round" stroke-linecap="round"/>
-        <text x="8" y="14" data-i18n="socialsTitle">SOCIALS</text>
+        <text x="8" y="14" data-i18n="photoTitle">PHOTO</text>
       </svg>
-      <div class="folder-box" data-i18n="socialsContent">
-        AFTER HAVING WORKED WITH RESTAURANTS, BANDS, EVENTS AND STORES, I HAVE A DEEP UNDERSTANDING OF CONTENT PRODUCTION, GRASPING THE VIEWER’S ATTENTION AND ALGORITHM MANIPULATION.
+      <div class="folder-box" data-i18n="photoContent">
+        CAPTURING AUTHENTIC AND SHARP SCENES IN A VIVID AND RAW STATE, IN SPONTANEOUS OR PREPARED ENVIRONMENTS. MY FOCUS IS ON STAND-OUT DETAIL, WITH AN EYE FOR ELEMENTS WHICH FUNDAMENTALLY COMMUNICATE THE REQUIRED MESSAGE.
       </div>
     </div>
     <div class="folder-icon" data-index="3">
-      <svg viewBox="0 0 100 70" xmlns="http://www.w3.org/2000/svg">
-        <path d="M4,14 L4,6 A2,2 0 0 1 6,4 H42 Q44,4 46,6 L52,12 Q54,14 56,14 H92 Q96,14 96,18 V60 Q96,64 92,64 H8 Q4,64 4,60 Z" fill="var(--bg-main)" stroke="currentColor" stroke-width="1" stroke-linejoin="round" stroke-linecap="round"/>
-        <text x="8" y="14" data-i18n="artDirTitle">ART DIR.</text>
-      </svg>
-      <div class="folder-box" data-i18n="artDirContent">
-        AS A POLYVALENT CREATOR, I CAN ADAPT ALL FORMATS, MEDIUMS AND SKILLS INTO A SINGLE PROJECT. CONSTANTLY DEVELOPING NEW CREATIVE PROCESSES, WITH INSPIRATIONS AND REFERENCES OF A BROAD SPECTRUM, I HAVE A PASSION FOR IMAGE TREATMENT AND EFFECTS, PRESENTING MY WORK IN A SIGNATURE STYLE.
-      </div>
-    </div>
-    <div class="folder-icon" data-index="4">
       <svg viewBox="0 0 100 70" xmlns="http://www.w3.org/2000/svg">
         <path d="M4,14 L4,6 A2,2 0 0 1 6,4 H42 Q44,4 46,6 L52,12 Q54,14 56,14 H92 Q96,14 96,18 V60 Q96,64 92,64 H8 Q4,64 4,60 Z" fill="var(--bg-main)" stroke="currentColor" stroke-width="1" stroke-linejoin="round" stroke-linecap="round"/>
         <text x="8" y="14" data-i18n="webTitle">WEB</text>
@@ -860,13 +854,22 @@
         I AM PROFICIENT AT DEVELOPING INTERACTIVE USER-FRIENDLY INTERFACES, BOTH FRONT-END AND BACK-END, EXPRESSING UNIQUE AND AMBITIOUS CONCEPTS CONCENTRATING ON THE DATA THAT MATTERS MOST.
       </div>
     </div>
+    <div class="folder-icon" data-index="4">
+      <svg viewBox="0 0 100 70" xmlns="http://www.w3.org/2000/svg">
+        <path d="M4,14 L4,6 A2,2 0 0 1 6,4 H42 Q44,4 46,6 L52,12 Q54,14 56,14 H92 Q96,14 96,18 V60 Q96,64 92,64 H8 Q4,64 4,60 Z" fill="var(--bg-main)" stroke="currentColor" stroke-width="1" stroke-linejoin="round" stroke-linecap="round"/>
+        <text x="8" y="14" data-i18n="socialsTitle">SOCIALS</text>
+      </svg>
+      <div class="folder-box" data-i18n="socialsContent">
+        AFTER HAVING WORKED WITH RESTAURANTS, BANDS, EVENTS AND STORES, I HAVE A DEEP UNDERSTANDING OF CONTENT PRODUCTION, GRASPING THE VIEWER’S ATTENTION AND ALGORITHM MANIPULATION.
+      </div>
+    </div>
     <div class="folder-icon" data-index="5">
       <svg viewBox="0 0 100 70" xmlns="http://www.w3.org/2000/svg">
         <path d="M4,14 L4,6 A2,2 0 0 1 6,4 H42 Q44,4 46,6 L52,12 Q54,14 56,14 H92 Q96,14 96,18 V60 Q96,64 92,64 H8 Q4,64 4,60 Z" fill="var(--bg-main)" stroke="currentColor" stroke-width="1" stroke-linejoin="round" stroke-linecap="round"/>
-        <text x="8" y="14" data-i18n="designTitle">DESIGN</text>
+        <text x="8" y="14" data-i18n="artDirTitle">ART DIR.</text>
       </svg>
-      <div class="folder-box" data-i18n="designContent">
-        WHETHER IT BE LOGOS OR FULL-ON REBRANDING, OVERLAY ELEMENTS FOR VISUALS OR COMPLETE MOTION DESIGNS, FLYERS OR OUTRIGHT MAGAZINES, I AM ABLE TO PROVIDE THE GRAPHICS THAT REPRESENT YOUR CREATIVE IDEAS.
+      <div class="folder-box" data-i18n="artDirContent">
+        AS A POLYVALENT CREATOR, I CAN ADAPT ALL FORMATS, MEDIUMS AND SKILLS INTO A SINGLE PROJECT. CONSTANTLY DEVELOPING NEW CREATIVE PROCESSES, WITH INSPIRATIONS AND REFERENCES OF A BROAD SPECTRUM, I HAVE A PASSION FOR IMAGE TREATMENT AND EFFECTS, PRESENTING MY WORK IN A SIGNATURE STYLE.
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -1033,6 +1033,13 @@ document.addEventListener('DOMContentLoaded', () => {
       }, Math.max(fadeSeconds * 1000 + 120, 200));
     }
 
+    function isSoundActive(name) {
+      const entry = activeSounds.get(name);
+      if (!entry) return false;
+      if (entry.loop) return true;
+      return (entry.count ?? 0) > 0 && !entry.fading;
+    }
+
     function clearActiveSound(name) {
       const entry = activeSounds.get(name);
       if (!entry) return;
@@ -1112,6 +1119,7 @@ document.addEventListener('DOMContentLoaded', () => {
         cooldown = DEFAULT_COOLDOWN,
         allowOverlap = false
       } = options;
+      if (!allowOverlap && isSoundActive(name)) return;
       if (!allowOverlap && isCoolingDown(name, cooldown)) return;
       markCooldown(name, cooldown);
       unlock();

--- a/index.html
+++ b/index.html
@@ -928,9 +928,9 @@ document.addEventListener('DOMContentLoaded', () => {
   let featureVideoMuted = true;
   let galleryAnimationId = null;
   let galleryTrack = null;
-  let galleryLoopWidth = 0;
-  let galleryOffset = 0;
   let galleryLastTs = 0;
+  let galleryShift = 0;
+  let galleryItemGap = 0;
   const GALLERY_SPEED = 40; // pixels per second
   const DIRECT_VIDEO_EXT = /\.(mp4|webm|ogg)(?:\?.*)?$/i;
   const IMAGE_EXT = /\.(?:apng|avif|gif|jpe?g|jfif|pjpe?g|pjp|png|svg|webp)$/i;
@@ -955,6 +955,78 @@ document.addEventListener('DOMContentLoaded', () => {
       return trimmed;
     }
   });
+
+  function collectMediaSources(entry) {
+    const sources = [];
+    const seen = new Set();
+    const addSource = value => {
+      if (typeof value !== 'string') return;
+      const normalised = safeNormaliseMediaSource(value);
+      if (!normalised || seen.has(normalised)) return;
+      seen.add(normalised);
+      sources.push(normalised);
+    };
+
+    if (!entry) return sources;
+
+    if (typeof entry === 'string') {
+      addSource(entry);
+      return sources;
+    }
+
+    if (typeof entry !== 'object') {
+      return sources;
+    }
+
+    ['src', 'href', 'url', 'poster', 'path', 'file'].forEach(key => {
+      if (typeof entry[key] === 'string') {
+        addSource(entry[key]);
+      }
+    });
+
+    if (Array.isArray(entry.sources)) {
+      entry.sources.forEach(source => {
+        if (!source) return;
+        if (typeof source === 'string') {
+          addSource(source);
+        } else if (typeof source === 'object') {
+          if (typeof source.src === 'string') addSource(source.src);
+          if (typeof source.url === 'string') addSource(source.url);
+        }
+      });
+    }
+
+    if (Array.isArray(entry.files)) {
+      entry.files.forEach(source => {
+        if (!source) return;
+        if (typeof source === 'string') {
+          addSource(source);
+        } else if (typeof source === 'object') {
+          if (typeof source.src === 'string') addSource(source.src);
+          if (typeof source.url === 'string') addSource(source.url);
+        }
+      });
+    }
+
+    if (Array.isArray(entry.images)) {
+      entry.images.forEach(source => {
+        if (!source) return;
+        if (typeof source === 'string') {
+          addSource(source);
+        } else if (typeof source === 'object') {
+          if (typeof source.src === 'string') addSource(source.src);
+          if (typeof source.url === 'string') addSource(source.url);
+        }
+      });
+    }
+
+    return sources;
+  }
+
+  function extractPrimaryMediaSource(entry) {
+    const sources = collectMediaSources(entry);
+    return sources.length ? sources[0] : '';
+  }
 
   function shouldPreloadMedia(src) {
     if (!src) return false;
@@ -1016,7 +1088,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function queueMediaPreloads(list) {
     if (!Array.isArray(list)) return;
-    list.forEach(src => scheduleMediaPreload(src));
+    list.forEach(entry => {
+      if (!entry) return;
+      if (typeof entry === 'string') {
+        scheduleMediaPreload(entry);
+        return;
+      }
+      collectMediaSources(entry).forEach(src => scheduleMediaPreload(src));
+    });
   }
 
   function queuePortfolioMediaPreload(manifest) {
@@ -1026,12 +1105,32 @@ document.addEventListener('DOMContentLoaded', () => {
       const items = Array.isArray(folder?.items) ? folder.items : [];
       items.forEach(item => {
         const mediaList = Array.isArray(item?.media) ? item.media : [];
-        mediaList.forEach(src => {
-          const normalised = safeNormaliseMediaSource(src);
-          if (!normalised || unique.has(normalised)) return;
-          unique.add(normalised);
-          scheduleMediaPreload(normalised);
+        mediaList.forEach(entry => {
+          collectMediaSources(entry).forEach(src => {
+            if (unique.has(src)) return;
+            unique.add(src);
+            scheduleMediaPreload(src);
+          });
         });
+        const featureVideo = item?.featureVideo;
+        if (featureVideo && typeof featureVideo === 'object') {
+          if (typeof featureVideo.poster === 'string') {
+            collectMediaSources({ src: featureVideo.poster }).forEach(src => {
+              if (unique.has(src)) return;
+              unique.add(src);
+              scheduleMediaPreload(src);
+            });
+          }
+          if (Array.isArray(featureVideo.posters)) {
+            featureVideo.posters.forEach(entry => {
+              collectMediaSources(entry).forEach(src => {
+                if (unique.has(src)) return;
+                unique.add(src);
+                scheduleMediaPreload(src);
+              });
+            });
+          }
+        }
       });
     });
   }
@@ -1824,36 +1923,58 @@ document.addEventListener('DOMContentLoaded', () => {
       cancelAnimationFrame(galleryAnimationId);
       galleryAnimationId = null;
     }
+    if (galleryTrack) {
+      galleryTrack.style.transform = '';
+    }
     galleryTrack = null;
-    galleryLoopWidth = 0;
-    galleryOffset = 0;
     galleryLastTs = 0;
+    galleryShift = 0;
+    galleryItemGap = 0;
   }
 
   function galleryStep(timestamp) {
-    if (!galleryTrack || galleryLoopWidth <= 0) {
+    if (!galleryTrack) {
       galleryAnimationId = null;
       return;
     }
     if (!galleryLastTs) galleryLastTs = timestamp;
-    const delta = (timestamp - galleryLastTs) / 1000;
+    const delta = Math.max(0, (timestamp - galleryLastTs) / 1000);
     galleryLastTs = timestamp;
-    galleryOffset = (galleryOffset + GALLERY_SPEED * delta) % galleryLoopWidth;
-    galleryTrack.style.transform = `translateX(${-galleryOffset}px)`;
+    galleryShift -= GALLERY_SPEED * delta;
+    normalizeGalleryShift();
+    galleryTrack.style.transform = `translate3d(${galleryShift}px, 0, 0)`;
     galleryAnimationId = requestAnimationFrame(galleryStep);
+  }
+
+  function normalizeGalleryShift() {
+    if (!galleryTrack) return;
+    if (!Number.isFinite(galleryItemGap) || galleryItemGap < 0) {
+      galleryItemGap = 0;
+    }
+    let guard = 0;
+    while (guard < 32) {
+      const first = galleryTrack.firstElementChild;
+      if (!first) break;
+      const width = first.getBoundingClientRect().width || first.offsetWidth || 0;
+      if (!(width > 0)) break;
+      const threshold = -(width + galleryItemGap);
+      if (galleryShift > threshold) break;
+      galleryShift += width + galleryItemGap;
+      galleryTrack.appendChild(first);
+      guard += 1;
+    }
   }
 
   function startGalleryLoop(track) {
     stopGalleryLoop();
     if (!track) return;
     galleryTrack = track;
-    galleryLoopWidth = track.scrollWidth / 2 || track.scrollWidth;
-    if (galleryLoopWidth <= 0) {
-      galleryTrack = null;
-      return;
-    }
-    galleryOffset = 0;
     galleryLastTs = 0;
+    galleryShift = 0;
+    const computed = window.getComputedStyle(track);
+    const gapValue = parseFloat(computed.columnGap || computed.gap || '0');
+    galleryItemGap = Number.isFinite(gapValue) && gapValue > 0 ? gapValue : 0;
+    track.style.transform = 'translate3d(0, 0, 0)';
     galleryAnimationId = requestAnimationFrame(galleryStep);
   }
 
@@ -1918,68 +2039,101 @@ document.addEventListener('DOMContentLoaded', () => {
     stopGalleryLoop();
   }
 
-  function renderFeatureGallery(media = [], label = 'MEDIA') {
+  function renderFeatureGallery(media = [], label = 'MEDIA', preloadTargets = media) {
     if (!featureGallery) return;
     clearFeatureGallery();
-    if (!media.length) return;
 
-    queueMediaPreloads(media);
+    const list = Array.isArray(media)
+      ? media.map(entry => (typeof entry === 'string' ? entry : extractPrimaryMediaSource(entry))).filter(Boolean)
+      : [];
+
+    if (!list.length) return;
+
+    const preloadList = Array.isArray(preloadTargets) && preloadTargets.length ? preloadTargets : list;
+    queueMediaPreloads(preloadList);
+
     const track = document.createElement('div');
     track.className = 'feature-gallery-track';
-    const sources = media.length === 1 ? media.concat(media) : media.concat(media);
-    sources.forEach((src, index) => {
+    featureGallery.appendChild(track);
+    featureGallery.classList.add('active');
+
+    const baseSources = list.slice();
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const minTrackWidth = viewportWidth ? viewportWidth * 2.1 : 0;
+
+    let pending = 0;
+    let loopStarted = false;
+
+    const maybeActivate = () => {
+      if (loopStarted || pending > 0) {
+        return;
+      }
+      ensureCoverage();
+      if (pending > 0) {
+        return;
+      }
+      loopStarted = true;
+      startGalleryLoop(track);
+      resizeActiveGalleryItems();
+    };
+
+    const ensureCoverage = () => {
+      if (!baseSources.length) return;
+      const computed = window.getComputedStyle(track);
+      const gapValue = parseFloat(computed.columnGap || computed.gap || '0') || 0;
+      const firstCycle = Array.from(track.children).slice(0, baseSources.length);
+      if (!firstCycle.length) return;
+      const cycleWidth = firstCycle.reduce((total, el, index) => {
+        const rectWidth = el.getBoundingClientRect().width || el.offsetWidth || 0;
+        if (!(rectWidth > 0)) return total;
+        return total + rectWidth + (index < firstCycle.length - 1 ? gapValue : 0);
+      }, 0);
+      if (!(cycleWidth > 0)) return;
+      const targetWidth = minTrackWidth || cycleWidth * 3;
+      let guard = 0;
+      while (track.scrollWidth < targetWidth && guard < 6) {
+        baseSources.forEach((src, idx) => addItem(src, idx + 1));
+        guard += 1;
+      }
+    };
+
+    function addItem(src, displayIndex) {
+      const resolvedSrc = safeNormaliseMediaSource(src);
+      const finalSrc = resolvedSrc || (typeof src === 'string' ? src : '');
+      if (!finalSrc) return;
       const button = document.createElement('button');
       button.type = 'button';
       button.className = 'feature-gallery-item';
       const img = document.createElement('img');
-      const resolvedSrc = safeNormaliseMediaSource(src);
-      const finalSrc = resolvedSrc || src;
-      if (finalSrc) {
-        img.src = finalSrc;
-      }
+      img.src = finalSrc;
       img.decoding = 'async';
-      if (index < media.length) {
-        try { img.fetchPriority = 'high'; } catch (_) {}
-      }
-      const baseIndex = (index % media.length) + 1;
-      img.alt = `${label} preview ${baseIndex}`;
+      img.loading = 'eager';
+      try { img.fetchPriority = 'high'; } catch (_) {}
+      img.alt = `${label} preview ${displayIndex}`;
       button.appendChild(img);
       button.addEventListener('click', () => {
         playEffect(SOUND_FILES.imageClick, { volume: 0.6 });
         openImageOverlay(finalSrc);
       });
-      const sizeHandler = () => adjustGalleryItemSize(button, img);
-      if (img.complete && img.naturalWidth > 0 && img.naturalHeight > 0) {
-        sizeHandler();
-      } else {
-        img.addEventListener('load', sizeHandler, { once: true });
-        img.addEventListener('error', () => adjustGalleryItemSize(button, img), { once: true });
-      }
       track.appendChild(button);
-    });
-    featureGallery.appendChild(track);
-    featureGallery.classList.add('active');
-    const images = Array.from(track.querySelectorAll('img'));
-    let pending = images.length;
-    const maybeStart = () => {
-      pending -= 1;
-      if (pending <= 0) {
-        startGalleryLoop(track);
-        resizeActiveGalleryItems();
+      pending += 1;
+      const finalize = () => {
+        adjustGalleryItemSize(button, img);
+        pending = Math.max(0, pending - 1);
+        maybeActivate();
+      };
+      if (img.complete && img.naturalWidth > 0 && img.naturalHeight > 0) {
+        requestAnimationFrame(finalize);
+      } else {
+        img.addEventListener('load', finalize, { once: true });
+        img.addEventListener('error', finalize, { once: true });
       }
-    };
-    if (!images.length) {
-      startGalleryLoop(track);
-    } else {
-      images.forEach(img => {
-        if (img.complete && img.naturalWidth > 0) {
-          maybeStart();
-        } else {
-          img.addEventListener('load', maybeStart, { once: true });
-          img.addEventListener('error', maybeStart, { once: true });
-        }
-      });
     }
+
+    baseSources.forEach((src, idx) => addItem(src, idx + 1));
+    baseSources.forEach((src, idx) => addItem(src, idx + 1));
+
+    maybeActivate();
   }
 
   function renderFeatureLinkMarquee(linkText) {
@@ -2185,7 +2339,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (preferLinkMarquee) {
       renderFeatureLinkMarquee(externalLink);
     } else if (!hasVideo && hasImages) {
-      renderFeatureGallery(media, label);
+      const preloadList = Array.isArray(entry.mediaPreload) && entry.mediaPreload.length
+        ? entry.mediaPreload
+        : media;
+      renderFeatureGallery(media, label, preloadList);
     } else if (!hasVideo && !hasImages && externalLink) {
       renderFeatureLinkMarquee(externalLink);
     } else if (!hasVideo && !hasImages && !externalLink) {
@@ -2946,10 +3103,27 @@ document.addEventListener('DOMContentLoaded', () => {
     return items.map((item, idx) => {
       const label = (item && item.label) ? item.label : String(item && item.id || idx + 1).replace(/^[0-9]+_/, '').replace(/_/g, ' ').toUpperCase();
       const index = (item && item.index) ? item.index.padStart(2, '0') : String(idx + 1).padStart(2, '0');
-      const media = Array.isArray(item?.media)
-        ? item.media.map(entry => safeNormaliseMediaSource(entry)).filter(Boolean)
-        : [];
-      let featureVideo = normaliseFeatureVideo(item?.featureVideo);
+      const rawMediaList = Array.isArray(item?.media) ? item.media : [];
+      const mediaPreloadSet = new Set();
+      const media = rawMediaList
+        .map(entry => {
+          const sources = collectMediaSources(entry);
+          sources.forEach(src => mediaPreloadSet.add(src));
+          return sources.length ? sources[0] : '';
+        })
+        .filter(Boolean);
+      const rawFeatureVideo = item?.featureVideo;
+      let featureVideo = normaliseFeatureVideo(rawFeatureVideo);
+      if (rawFeatureVideo && typeof rawFeatureVideo === 'object') {
+        if (typeof rawFeatureVideo.poster === 'string') {
+          collectMediaSources({ src: rawFeatureVideo.poster }).forEach(src => mediaPreloadSet.add(src));
+        }
+        if (Array.isArray(rawFeatureVideo.posters)) {
+          rawFeatureVideo.posters.forEach(entry => {
+            collectMediaSources(entry).forEach(src => mediaPreloadSet.add(src));
+          });
+        }
+      }
       const externalLink = typeof item?.externalLink === 'string' ? item.externalLink.trim() : '';
       const requestedAspect = typeof item?.videoAspectRatio === 'string' ? item.videoAspectRatio.trim() : '';
       if (!featureVideo && externalLink && media.length > 0 && isEmbedVideoLink(externalLink)) {
@@ -2959,6 +3133,10 @@ document.addEventListener('DOMContentLoaded', () => {
         };
       }
       const base = { index, label, media, externalLink };
+      const mediaPreload = Array.from(mediaPreloadSet);
+      if (mediaPreload.length) {
+        base.mediaPreload = mediaPreload;
+      }
       return featureVideo ? { ...base, featureVideo } : base;
     });
   }

--- a/index.html
+++ b/index.html
@@ -921,6 +921,108 @@ document.addEventListener('DOMContentLoaded', () => {
   let galleryLastTs = 0;
   const GALLERY_SPEED = 40; // pixels per second
   const DIRECT_VIDEO_EXT = /\.(mp4|webm|ogg)(?:\?.*)?$/i;
+  const IMAGE_EXT = /\.(?:apng|avif|gif|jpe?g|jfif|pjpe?g|pjp|png|svg|webp)$/i;
+
+  const MASTER_VOLUME = 0.6;
+
+  const mediaPreloadCache = new Map();
+  const mediaPreloadQueue = new Set();
+  let mediaPreloadActive = 0;
+  const MEDIA_PRELOAD_CONCURRENCY = 3;
+  const scheduleIdle = (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function')
+    ? (cb => window.requestIdleCallback(cb, { timeout: 2000 }))
+    : (cb => setTimeout(() => cb({ didTimeout: false, timeRemaining: () => 0 }), 200));
+
+  function normaliseMediaSource(raw) {
+    if (typeof raw !== 'string') return '';
+    const trimmed = raw.trim();
+    if (!trimmed) return '';
+    try {
+      return encodeURI(trimmed);
+    } catch (_) {
+      return trimmed;
+    }
+  }
+
+  function shouldPreloadMedia(src) {
+    if (!src) return false;
+    const clean = src.split('#')[0].split('?')[0];
+    return IMAGE_EXT.test(clean);
+  }
+
+  function preloadImageAsset(src) {
+    const normalised = normaliseMediaSource(src);
+    if (!normalised || !shouldPreloadMedia(normalised)) {
+      return Promise.resolve(null);
+    }
+    if (mediaPreloadCache.has(normalised)) {
+      return mediaPreloadCache.get(normalised);
+    }
+    const promise = new Promise(resolve => {
+      const img = new Image();
+      img.decoding = 'async';
+      img.loading = 'eager';
+      const done = () => {
+        img.onload = null;
+        img.onerror = null;
+        resolve(normalised);
+      };
+      img.onload = done;
+      img.onerror = done;
+      img.src = normalised;
+    });
+    mediaPreloadCache.set(normalised, promise);
+    return promise;
+  }
+
+  function drainMediaPreloadQueue(deadline) {
+    if (!mediaPreloadQueue.size) return;
+    const timeRemaining = typeof deadline?.timeRemaining === 'function'
+      ? () => deadline.timeRemaining()
+      : () => 0;
+    while (mediaPreloadActive < MEDIA_PRELOAD_CONCURRENCY && mediaPreloadQueue.size) {
+      if (timeRemaining() <= 1 && mediaPreloadActive > 0) break;
+      const iterator = mediaPreloadQueue.values().next();
+      if (iterator.done) break;
+      const src = iterator.value;
+      mediaPreloadQueue.delete(src);
+      mediaPreloadActive++;
+      preloadImageAsset(src).finally(() => {
+        mediaPreloadActive--;
+        scheduleIdle(drainMediaPreloadQueue);
+      });
+    }
+  }
+
+  function scheduleMediaPreload(src) {
+    const normalised = normaliseMediaSource(src);
+    if (!normalised || !shouldPreloadMedia(normalised)) return;
+    if (mediaPreloadCache.has(normalised) || mediaPreloadQueue.has(normalised)) return;
+    mediaPreloadQueue.add(normalised);
+    scheduleIdle(drainMediaPreloadQueue);
+  }
+
+  function queueMediaPreloads(list) {
+    if (!Array.isArray(list)) return;
+    list.forEach(src => scheduleMediaPreload(src));
+  }
+
+  function queuePortfolioMediaPreload(manifest) {
+    if (!manifest || !Array.isArray(manifest.folders)) return;
+    const unique = new Set();
+    manifest.folders.forEach(folder => {
+      const items = Array.isArray(folder?.items) ? folder.items : [];
+      items.forEach(item => {
+        const mediaList = Array.isArray(item?.media) ? item.media : [];
+        mediaList.forEach(src => {
+          const normalised = normaliseMediaSource(src);
+          if (!normalised || unique.has(normalised)) return;
+          unique.add(normalised);
+          scheduleMediaPreload(normalised);
+        });
+      });
+    });
+  }
 
   const SOUND_FILES = {
     click: 'click.wav',
@@ -967,7 +1069,8 @@ document.addEventListener('DOMContentLoaded', () => {
         isLoopActive() { return false; },
         setMasterMuted() {},
         getActiveSounds() { return []; },
-        onActiveChange() { return () => {}; }
+        onActiveChange() { return () => {}; },
+        preloadBuffers() { return Promise.resolve([]); }
       };
     }
 
@@ -975,7 +1078,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const ctx = new AudioCtx();
     const master = ctx.createGain();
     master.connect(ctx.destination);
-    master.gain.value = 1;
+    master.gain.value = MASTER_VOLUME;
 
     const buffers = new Map();
     const loading = new Map();
@@ -1139,7 +1242,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function setMasterMuted(muted, ramp = 0.2) {
       const duration = Math.max(0.05, typeof ramp === 'number' ? ramp : 0.2);
-      const target = muted ? 0.0001 : 1;
+      const target = muted ? 0.0001 : MASTER_VOLUME;
       const now = ctx.currentTime;
       master.gain.cancelScheduledValues(now);
       master.gain.setValueAtTime(master.gain.value, now);
@@ -1183,7 +1286,7 @@ document.addEventListener('DOMContentLoaded', () => {
           clips.delete(name);
           clearActiveSound(name);
         };
-        const safeVolume = Math.max(0, volume);
+        const safeVolume = Math.min(1, Math.max(0, volume));
         if (fadeIn > 0) {
           gain.gain.linearRampToValueAtTime(safeVolume, now + fadeIn);
         } else {
@@ -1227,7 +1330,7 @@ document.addEventListener('DOMContentLoaded', () => {
         source.loop = true;
         source.playbackRate.setValueAtTime(options.playbackRate || 1, now);
         const gain = ctx.createGain();
-        const targetVol = Math.max(0, options.volume ?? 1);
+        const targetVol = Math.min(1, Math.max(0, options.volume ?? 1));
         gain.gain.setValueAtTime(0.0001, now);
         source.connect(gain);
         gain.connect(master);
@@ -1250,7 +1353,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const entry = loops.get(name);
       if (!entry) return;
       const now = ctx.currentTime;
-      const target = Math.max(0, typeof volume === 'number' ? volume : entry.volumeTarget);
+      const target = Math.min(1, Math.max(0, typeof volume === 'number' ? volume : entry.volumeTarget));
       entry.volumeTarget = target;
       entry.gain.gain.cancelScheduledValues(now);
       const current = entry.gain.gain.value;
@@ -1303,11 +1406,21 @@ document.addEventListener('DOMContentLoaded', () => {
         return () => {
           debugListeners.delete(callback);
         };
+      },
+      preloadBuffers(names = []) {
+        if (!Array.isArray(names) || !names.length) return Promise.resolve([]);
+        return Promise.all(names.map(name => loadBuffer(name))).catch(() => []);
       }
     };
   }
 
   const soundController = createSoundController();
+  if (soundController.supported) {
+    const soundList = Object.values(SOUND_FILES);
+    scheduleIdle(() => {
+      soundController.preloadBuffers(soundList).catch(() => {});
+    });
+  }
   const audioSupported = Boolean(soundController && soundController.supported);
   const SOUND_PREF_KEY = 'ms-sound-enabled';
   let interactiveAudioEnabled = true;
@@ -1794,6 +1907,7 @@ document.addEventListener('DOMContentLoaded', () => {
     clearFeatureGallery();
     if (!media.length) return;
 
+    queueMediaPreloads(media);
     const track = document.createElement('div');
     track.className = 'feature-gallery-track';
     const sources = media.length === 1 ? media.concat(media) : media.concat(media);
@@ -1802,13 +1916,21 @@ document.addEventListener('DOMContentLoaded', () => {
       button.type = 'button';
       button.className = 'feature-gallery-item';
       const img = document.createElement('img');
-      img.src = src;
+      const resolvedSrc = normaliseMediaSource(src);
+      const finalSrc = resolvedSrc || src;
+      if (finalSrc) {
+        img.src = finalSrc;
+      }
+      img.decoding = 'async';
+      if (index < media.length) {
+        try { img.fetchPriority = 'high'; } catch (_) {}
+      }
       const baseIndex = (index % media.length) + 1;
       img.alt = `${label} preview ${baseIndex}`;
       button.appendChild(img);
       button.addEventListener('click', () => {
         playEffect(SOUND_FILES.imageClick, { volume: 0.6 });
-        openImageOverlay(src);
+        openImageOverlay(finalSrc);
       });
       const sizeHandler = () => adjustGalleryItemSize(button, img);
       if (img.complete && img.naturalWidth > 0 && img.naturalHeight > 0) {
@@ -1887,7 +2009,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function openImageOverlay(src) {
     if (!featureImageOverlay || !featureImageOverlayImg) return;
-    featureImageOverlayImg.src = src;
+    const resolved = normaliseMediaSource(src);
+    featureImageOverlayImg.src = resolved || src;
     featureImageOverlay.classList.add('visible');
   }
 
@@ -2808,7 +2931,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const label = (item && item.label) ? item.label : String(item && item.id || idx + 1).replace(/^[0-9]+_/, '').replace(/_/g, ' ').toUpperCase();
       const index = (item && item.index) ? item.index.padStart(2, '0') : String(idx + 1).padStart(2, '0');
       const media = Array.isArray(item?.media)
-        ? item.media.map(entry => String(entry))
+        ? item.media.map(entry => normaliseMediaSource(entry)).filter(Boolean)
         : [];
       let featureVideo = normaliseFeatureVideo(item?.featureVideo);
       const externalLink = typeof item?.externalLink === 'string' ? item.externalLink.trim() : '';
@@ -2848,7 +2971,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function loadPortfolioManifest() {
     try {
-      const response = await fetch('portfolio_manifest.json', { cache: 'no-store' });
+      const response = await fetch('portfolio_manifest.json', { cache: 'no-cache' });
       if (response.ok) {
         const json = await response.json();
         if (json && Array.isArray(json.folders)) {
@@ -2860,6 +2983,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     applyPortfolio(portfolioManifest);
     sendPortfolio();
+    queuePortfolioMediaPreload(portfolioManifest);
   }
 
   if (orbitIframe) orbitIframe.addEventListener('load', sendPortfolio);

--- a/index.html
+++ b/index.html
@@ -532,6 +532,10 @@
       flex: 0 0 auto;
     }
 
+    .feature-gallery-track--links {
+      font-family: 'Ferrite Display', sans-serif;
+    }
+
     .feature-gallery-item {
       position: relative;
       display: flex;
@@ -770,8 +774,12 @@
         transform: translateY(-150vh);
         opacity: 0;
       }
+      72% {
+        transform: translateY(calc(var(--drop-rest, 0px) - 26px));
+        opacity: 1;
+      }
       100% {
-        transform: translateY(0);
+        transform: translateY(var(--drop-rest, 0px));
         opacity: 1;
       }
     }
@@ -791,8 +799,13 @@
       scrollbar-width: thin;
     }
 
+    html.scroll-lock,
     body.scroll-lock {
       overflow: hidden;
+    }
+
+    html.scroll-lock {
+      height: 100%;
     }
 
   </style>
@@ -909,6 +922,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const featureLinkTrack = document.getElementById('featureLinkTrack');
   const featureImageOverlay = document.getElementById('featureImageOverlay');
   const featureImageOverlayImg = featureImageOverlay ? featureImageOverlay.querySelector('img') : null;
+  const rootElement = document.documentElement;
+  const initialBodyStyles = {
+    position: document.body.style.position,
+    top: document.body.style.top,
+    width: document.body.style.width,
+    touchAction: document.body.style.touchAction
+  };
 
   const THEMES = {
     light: { accent: '#1449ff', topoBg: '#faf8e5', topoLine: '#ffffff' },
@@ -2029,7 +2049,7 @@ document.addEventListener('DOMContentLoaded', () => {
   descriptionText.style.visibility = 'hidden';
   history.scrollRestoration = 'manual';
   window.scrollTo(0, 0);
-  requestAnimationFrame(() => window.scrollTo(0, 1));
+  requestAnimationFrame(() => window.scrollTo(0, 0));
 
   const preventKeys = e => {
     if (!scrollUnlocked && ['ArrowUp','ArrowDown','PageUp','PageDown','Home','End',' '].includes(e.key)) {
@@ -2043,7 +2063,26 @@ document.addEventListener('DOMContentLoaded', () => {
   let scrollUnlocked = false;
   let queuedScrollTarget = null;
   let queuedScrollDuration = 0;
-  document.body.classList.add('scroll-lock');
+  function applyInitialScrollLockStyles() {
+    rootElement.classList.add('scroll-lock');
+    document.body.classList.add('scroll-lock');
+    document.body.style.position = 'fixed';
+    document.body.style.top = '0';
+    document.body.style.width = '100%';
+    document.body.style.touchAction = 'none';
+    window.scrollTo(0, 0);
+  }
+
+  function clearInitialScrollLockStyles() {
+    rootElement.classList.remove('scroll-lock');
+    document.body.classList.remove('scroll-lock');
+    document.body.style.position = initialBodyStyles.position;
+    document.body.style.top = initialBodyStyles.top;
+    document.body.style.width = initialBodyStyles.width;
+    document.body.style.touchAction = initialBodyStyles.touchAction;
+  }
+
+  applyInitialScrollLockStyles();
   if (scrollArrow) {
     scrollArrow.classList.add('locked');
   }
@@ -2058,7 +2097,7 @@ document.addEventListener('DOMContentLoaded', () => {
   window.addEventListener('keydown', preventKeys, { passive: false });
   setTimeout(() => {
     scrollUnlocked = true;
-    document.body.classList.remove('scroll-lock');
+    clearInitialScrollLockStyles();
     window.removeEventListener('wheel', preventScroll);
     window.removeEventListener('touchmove', preventScroll);
     window.removeEventListener('keydown', preventKeys);
@@ -2306,8 +2345,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const baseOffsets = {};
   sequence.forEach((idx, z) => icons[idx].style.zIndex = 100 - z);
   sequence.forEach((idx, i) => {
-    const ratio = sequence.length > 1 ? i / (sequence.length - 1) : 0;
-    const offset = 10 + ratio * 40;
+    const sway = Math.sin(i * 0.9 + 0.6);
+    const offset = 44 + sway * 28;
     baseOffsets[idx] = Math.round(offset);
   });
 
@@ -2413,12 +2452,16 @@ document.addEventListener('DOMContentLoaded', () => {
   setTimeout(() => {
     dropSequence.forEach((idx, i) => {
       const el = icons[idx];
-      el.style.animation = `dropIn 0.6s cubic-bezier(0.22,1,0.36,1) ${i * dropInterval}ms forwards`;
+      const restOffset = baseOffsets[idx] || 0;
+      const restValue = `-${restOffset}px`;
+      el.style.setProperty('--drop-rest', restValue);
+      el.style.transform = 'translateY(-150vh)';
+      el.style.opacity = '0';
+      el.style.animation = `dropIn 0.8s cubic-bezier(0.22,1,0.36,1) ${i * dropInterval}ms forwards`;
       el.addEventListener('animationend', () => {
         // persist final state so CSS defaults (off-screen/invisible) don't snap back
         el.style.animation = '';
-        const restOffset = baseOffsets[idx] || 0;
-        el.style.transform = `translateY(-${restOffset}px)`;
+        el.style.transform = `translateY(${restValue})`;
         el.style.opacity   = '1';
       }, { once: true });
     });
@@ -2426,6 +2469,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // --- SCROLL LIFT LOGIC ---
   window.addEventListener('scroll', () => {
+    if (!scrollUnlocked) {
+      if (window.scrollY !== 0) {
+        window.scrollTo(0, 0);
+      }
+      sendScroll();
+      return;
+    }
     const scrollY    = window.scrollY;
     const startFade  = sequence.indexOf(1) * spacing;
     const endFade    = startFade + spacing * 1.2;
@@ -2438,7 +2488,7 @@ document.addEventListener('DOMContentLoaded', () => {
       el.style.opacity = 1 - fadeRatio;
       el.style.filter  = `blur(${fadeRatio * 10}px)`;
     });
-  sequence.forEach((idx, i) => {
+    sequence.forEach((idx, i) => {
       const el    = icons[idx];
       const base  = baseOffsets[idx] || 0;
       const start = i * spacing;

--- a/index.html
+++ b/index.html
@@ -532,10 +532,6 @@
       flex: 0 0 auto;
     }
 
-    .feature-gallery-track--links {
-      font-family: 'Ferrite Display', sans-serif;
-    }
-
     .feature-gallery-item {
       position: relative;
       display: flex;
@@ -561,41 +557,19 @@
       transform-origin: center;
     }
 
-    .feature-gallery-link {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      height: 100%;
-      padding: 0 clamp(20px, 6vw, 48px);
-      border: 4px solid var(--accent);
-      color: var(--accent);
-      background: var(--bg-alt);
-      text-decoration: none;
-      font-family: 'Ferrite Display', sans-serif;
-      font-size: clamp(18px, 2.2vw, 34px);
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      white-space: nowrap;
-      transition: border-color var(--theme-transition) ease, color var(--theme-transition) ease, background-color var(--theme-transition) ease;
-    }
-
-    .feature-gallery.links-mode .feature-gallery-track {
-      gap: clamp(28px, 5vw, 72px);
-    }
-
     .feature-link-placeholder {
       width: var(--feature-video-width, min(80vw, 960px));
       max-width: min(80vw, 960px);
-      height: var(--feature-video-height);
-      border: 4px solid var(--accent);
-      background: var(--bg-alt);
-      box-shadow: 0 18px 44px rgba(0, 0, 0, 0.28);
+      min-height: clamp(140px, 20vh, var(--feature-video-height));
       display: none;
       align-items: center;
-      justify-content: center;
-      padding: 0;
-      text-align: center;
-      transition: background var(--theme-transition) ease, border-color var(--theme-transition) ease, color var(--theme-transition) ease;
+      justify-content: flex-start;
+      padding: clamp(12px, 2.6vh, 28px) 0;
+      text-align: left;
+      background: transparent;
+      border: none;
+      box-shadow: none;
+      transition: color var(--theme-transition) ease;
       overflow: hidden;
       position: relative;
     }
@@ -607,30 +581,25 @@
     .feature-link-track {
       display: flex;
       align-items: center;
-      gap: clamp(28px, 5vw, 72px);
+      gap: clamp(48px, 10vw, 180px);
       will-change: transform;
       min-width: 100%;
+      font-family: 'Ferrite Display', sans-serif;
+      font-size: clamp(36px, 7vw, 110px);
+      letter-spacing: 0.16em;
+      white-space: nowrap;
     }
 
     .feature-link-item {
+      flex: 0 0 auto;
       color: var(--accent);
       text-decoration: none;
-      font-size: clamp(22px, 2.6vw, 38px);
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      font-family: 'Ferrite Display', sans-serif;
       transition: color var(--theme-transition) ease;
-      white-space: nowrap;
     }
 
     .feature-link-item:hover,
     .feature-link-item:focus {
-      color: var(--bg-main);
-    }
-
-    .feature-link-placeholder a:hover,
-    .feature-link-placeholder a:focus {
-      color: var(--fg-main);
+      color: var(--bg-alt);
     }
 
     .feature-image-overlay {
@@ -1586,6 +1555,18 @@ document.addEventListener('DOMContentLoaded', () => {
     return url;
   }
 
+  function normaliseExternalLink(raw = '') {
+    const trimmed = (raw || '').trim();
+    if (!trimmed) return '';
+    if (trimmed.startsWith('//')) {
+      return `https:${trimmed}`;
+    }
+    if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) {
+      return trimmed;
+    }
+    return `https://${trimmed}`;
+  }
+
   function isEmbedVideoLink(url = '') {
     if (!url) return false;
     if (isDirectVideoUrl(url)) return true;
@@ -1749,7 +1730,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function clearFeatureGallery() {
     if (featureGallery) {
       featureGallery.innerHTML = '';
-      featureGallery.classList.remove('active', 'links-mode');
+      featureGallery.classList.remove('active');
     }
     stopGalleryLoop();
   }
@@ -1810,27 +1791,33 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function renderFeatureLinkMarquee(linkText) {
-    if (!featureGallery) return;
-    clearFeatureGallery();
+    if (!featureLinkPlaceholder || !featureLinkTrack) return;
     const trimmed = (linkText || '').trim();
     if (!trimmed) return;
 
-    const track = document.createElement('div');
-    track.className = 'feature-gallery-track feature-gallery-track--links';
-    const phrases = Array.from({ length: 6 }, () => trimmed);
+    stopGalleryLoop();
+    featureLinkTrack.innerHTML = '';
+    featureLinkTrack.style.transform = 'translateX(0)';
+
+    const url = normaliseExternalLink(trimmed);
+    const displayText = trimmed;
+    const phrases = Array.from({ length: 6 }, () => displayText);
     const total = phrases.length * 2;
+
     for (let i = 0; i < total; i++) {
       const anchor = document.createElement('a');
-      anchor.href = trimmed;
+      anchor.href = url;
       anchor.target = '_blank';
       anchor.rel = 'noopener noreferrer';
-      anchor.className = 'feature-gallery-link';
-      anchor.textContent = `${phrases[i % phrases.length]}  `;
-      track.appendChild(anchor);
+      anchor.className = 'feature-link-item';
+      anchor.textContent = phrases[i % phrases.length];
+      anchor.setAttribute('aria-label', `Open ${trimmed} in a new tab`);
+      featureLinkTrack.appendChild(anchor);
     }
-    featureGallery.appendChild(track);
-    featureGallery.classList.add('active', 'links-mode');
-    requestAnimationFrame(() => startGalleryLoop(track));
+
+    featureLinkPlaceholder.classList.add('active');
+    featureLinkPlaceholder.setAttribute('data-link', url);
+    requestAnimationFrame(() => startGalleryLoop(featureLinkTrack));
   }
 
   function hideLinkPlaceholder() {
@@ -1839,7 +1826,9 @@ document.addEventListener('DOMContentLoaded', () => {
     featureLinkPlaceholder.removeAttribute('data-link');
     if (featureLinkTrack) {
       featureLinkTrack.innerHTML = '';
+      featureLinkTrack.style.removeProperty('transform');
     }
+    stopGalleryLoop();
   }
 
   function openImageOverlay(src) {
@@ -2345,9 +2334,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const baseOffsets = {};
   sequence.forEach((idx, z) => icons[idx].style.zIndex = 100 - z);
   sequence.forEach((idx, i) => {
-    const sway = Math.sin(i * 0.9 + 0.6);
-    const offset = 44 + sway * 28;
-    baseOffsets[idx] = Math.round(offset);
+    const denom = sequence.length > 1 ? (sequence.length - 1) : 1;
+    baseOffsets[idx] = Math.round((i / denom) * 50);
   });
 
   function wrapText(text, container) {
@@ -2452,16 +2440,11 @@ document.addEventListener('DOMContentLoaded', () => {
   setTimeout(() => {
     dropSequence.forEach((idx, i) => {
       const el = icons[idx];
-      const restOffset = baseOffsets[idx] || 0;
-      const restValue = `-${restOffset}px`;
-      el.style.setProperty('--drop-rest', restValue);
-      el.style.transform = 'translateY(-150vh)';
-      el.style.opacity = '0';
-      el.style.animation = `dropIn 0.8s cubic-bezier(0.22,1,0.36,1) ${i * dropInterval}ms forwards`;
+      el.style.animation = `dropIn 0.6s cubic-bezier(0.22,1,0.36,1) ${i * dropInterval}ms forwards`;
       el.addEventListener('animationend', () => {
         // persist final state so CSS defaults (off-screen/invisible) don't snap back
         el.style.animation = '';
-        el.style.transform = `translateY(${restValue})`;
+        el.style.transform = 'translateY(0)';
         el.style.opacity   = '1';
       }, { once: true });
     });

--- a/index.html
+++ b/index.html
@@ -303,6 +303,11 @@
       transition: transform 4s cubic-bezier(.33,1,.68,1), background var(--theme-transition) ease, color var(--theme-transition) ease, border-color var(--theme-transition) ease;
     }
 
+    #scrollArrow.locked {
+      pointer-events: none;
+      opacity: 0.55;
+    }
+
     #modeToggle {
       position: fixed;
       top: 12px;
@@ -524,6 +529,7 @@
       align-items: center;
       will-change: transform;
       min-width: 100%;
+      flex: 0 0 auto;
     }
 
     .feature-gallery-item {
@@ -547,6 +553,8 @@
       width: 100%;
       display: block;
       object-fit: cover;
+      transform: scale(1.05);
+      transform-origin: center;
     }
 
     .feature-gallery-link {
@@ -750,17 +758,12 @@
       border: none;
       background: transparent;
       z-index: 1;
-    }
-
-    .portfolio-orbit-fade {
-      position: absolute;
-      top: 550vh;
-      left: 0;
-      width: 100vw;
-      height: clamp(120px, 18vh, 240px);
-      pointer-events: none;
-      z-index: 2;
-      background: linear-gradient(to top, var(--bg-main) 0%, transparent 100%);
+      -webkit-mask-image: linear-gradient(to top, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 70%, rgba(0, 0, 0, 0) 100%);
+      mask-image: linear-gradient(to top, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 70%, rgba(0, 0, 0, 0) 100%);
+      -webkit-mask-size: 100% 100%;
+      mask-size: 100% 100%;
+      -webkit-mask-repeat: no-repeat;
+      mask-repeat: no-repeat;
     }
     @keyframes dropIn {
       0% {
@@ -1907,7 +1910,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const media = Array.isArray(entry.media) ? entry.media.filter(Boolean) : [];
     const hasImages = media.length > 0;
     const externalLink = typeof entry.externalLink === 'string' ? entry.externalLink.trim() : '';
-    const preferLinkMarquee = !hasVideo && externalLink && folderName.toLowerCase() === 'web';
+    const preferLinkMarquee = externalLink && folderName.toLowerCase() === 'web';
 
     featureVideoShell.classList.add('visible');
     if (featureVideoPlaceholder) {
@@ -2038,7 +2041,12 @@ document.addEventListener('DOMContentLoaded', () => {
   let gridOpen = false;
   let pendingScroll = null;
   let scrollUnlocked = false;
+  let queuedScrollTarget = null;
+  let queuedScrollDuration = 0;
   document.body.classList.add('scroll-lock');
+  if (scrollArrow) {
+    scrollArrow.classList.add('locked');
+  }
   const preventScroll = e => {
     if (!scrollUnlocked) {
       e.preventDefault();
@@ -2054,8 +2062,18 @@ document.addEventListener('DOMContentLoaded', () => {
     window.removeEventListener('wheel', preventScroll);
     window.removeEventListener('touchmove', preventScroll);
     window.removeEventListener('keydown', preventKeys);
+    if (scrollArrow) {
+      scrollArrow.classList.remove('locked');
+    }
     window.scrollTo(0, Math.max(window.scrollY, 1));
-  }, 5000);
+    const nextTarget = queuedScrollTarget;
+    const nextDuration = queuedScrollDuration;
+    queuedScrollTarget = null;
+    queuedScrollDuration = 0;
+    if (nextTarget !== null) {
+      smoothScrollTo(nextTarget, nextDuration);
+    }
+  }, 7000);
 
   function updateScrollbar() {
     if (!scrollbarProgress) return;
@@ -2064,6 +2082,7 @@ document.addEventListener('DOMContentLoaded', () => {
     scrollbarProgress.style.height = `${ratio * 100}%`;
   }
   function updateArrow() {
+    if (!scrollArrow) return;
     const scrollY = window.scrollY;
     const bottomThreshold = document.body.scrollHeight - 2 * window.innerHeight;
     const topThreshold = window.innerHeight;
@@ -2076,6 +2095,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
   function smoothScrollTo(target, duration) {
+    if (!scrollUnlocked) {
+      queuedScrollTarget = target;
+      queuedScrollDuration = duration;
+      return;
+    }
     if (!duration || duration <= 0) {
       window.scrollTo(0, target);
       return;
@@ -2092,23 +2116,26 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     requestAnimationFrame(step);
   }
-  scrollArrow.addEventListener('click', () => {
-    if (goTop) {
-      if (gridOpen) {
-        triggerAutoScrollSound(4000);
-        pendingScroll = 0;
-        orbitFrame.contentWindow.postMessage({ closeGrid: true }, '*');
+  if (scrollArrow) {
+    scrollArrow.addEventListener('click', () => {
+      if (!scrollUnlocked) return;
+      if (goTop) {
+        if (gridOpen) {
+          triggerAutoScrollSound(4000);
+          pendingScroll = 0;
+          orbitFrame.contentWindow.postMessage({ closeGrid: true }, '*');
+        } else {
+          triggerAutoScrollSound(4000);
+          smoothScrollTo(0, 4000);
+        }
+        goTop = false;
       } else {
         triggerAutoScrollSound(4000);
-        smoothScrollTo(0, 4000);
+        smoothScrollTo(document.body.scrollHeight, 4000);
+        goTop = true;
       }
-      goTop = false;
-    } else {
-      triggerAutoScrollSound(4000);
-      smoothScrollTo(document.body.scrollHeight, 4000);
-      goTop = true;
-    }
-  });
+    });
+  }
   function handleScrollClose(){
     if(!gridOpen) return;
     const rect = orbitFrame.getBoundingClientRect();
@@ -2279,7 +2306,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const baseOffsets = {};
   sequence.forEach((idx, z) => icons[idx].style.zIndex = 100 - z);
   sequence.forEach((idx, i) => {
-    baseOffsets[idx] = Math.round((i / (sequence.length - 1)) * 50);
+    const ratio = sequence.length > 1 ? i / (sequence.length - 1) : 0;
+    const offset = 10 + ratio * 40;
+    baseOffsets[idx] = Math.round(offset);
   });
 
   function wrapText(text, container) {
@@ -2388,7 +2417,8 @@ document.addEventListener('DOMContentLoaded', () => {
       el.addEventListener('animationend', () => {
         // persist final state so CSS defaults (off-screen/invisible) don't snap back
         el.style.animation = '';
-        el.style.transform = 'translateY(0)';
+        const restOffset = baseOffsets[idx] || 0;
+        el.style.transform = `translateY(-${restOffset}px)`;
         el.style.opacity   = '1';
       }, { once: true });
     });
@@ -2608,7 +2638,6 @@ document.addEventListener('DOMContentLoaded', () => {
   </div>
 
   <iframe src="orbit_inner.html" class="portfolio-orbit"></iframe>
-  <div class="portfolio-orbit-fade" aria-hidden="true"></div>
 
   <footer class="page-footer">
     <div class="real-footer" data-i18n="fontCredit">Ferrite Display Font by @willaggett</div>

--- a/index.html
+++ b/index.html
@@ -933,7 +933,7 @@ document.addEventListener('DOMContentLoaded', () => {
     ? (cb => window.requestIdleCallback(cb, { timeout: 2000 }))
     : (cb => setTimeout(() => cb({ didTimeout: false, timeRemaining: () => 0 }), 200));
 
-  function normaliseMediaSource(raw) {
+  function safeNormaliseMediaSource(raw) {
     if (typeof raw !== 'string') return '';
     const trimmed = raw.trim();
     if (!trimmed) return '';
@@ -951,7 +951,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function preloadImageAsset(src) {
-    const normalised = normaliseMediaSource(src);
+    const normalised = safeNormaliseMediaSource(src);
     if (!normalised || !shouldPreloadMedia(normalised)) {
       return Promise.resolve(null);
     }
@@ -995,7 +995,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function scheduleMediaPreload(src) {
-    const normalised = normaliseMediaSource(src);
+    const normalised = safeNormaliseMediaSource(src);
     if (!normalised || !shouldPreloadMedia(normalised)) return;
     if (mediaPreloadCache.has(normalised) || mediaPreloadQueue.has(normalised)) return;
     mediaPreloadQueue.add(normalised);
@@ -1015,7 +1015,7 @@ document.addEventListener('DOMContentLoaded', () => {
       items.forEach(item => {
         const mediaList = Array.isArray(item?.media) ? item.media : [];
         mediaList.forEach(src => {
-          const normalised = normaliseMediaSource(src);
+          const normalised = safeNormaliseMediaSource(src);
           if (!normalised || unique.has(normalised)) return;
           unique.add(normalised);
           scheduleMediaPreload(normalised);
@@ -1916,7 +1916,7 @@ document.addEventListener('DOMContentLoaded', () => {
       button.type = 'button';
       button.className = 'feature-gallery-item';
       const img = document.createElement('img');
-      const resolvedSrc = normaliseMediaSource(src);
+      const resolvedSrc = safeNormaliseMediaSource(src);
       const finalSrc = resolvedSrc || src;
       if (finalSrc) {
         img.src = finalSrc;
@@ -2009,7 +2009,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function openImageOverlay(src) {
     if (!featureImageOverlay || !featureImageOverlayImg) return;
-    const resolved = normaliseMediaSource(src);
+    const resolved = safeNormaliseMediaSource(src);
     featureImageOverlayImg.src = resolved || src;
     featureImageOverlay.classList.add('visible');
   }
@@ -2931,7 +2931,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const label = (item && item.label) ? item.label : String(item && item.id || idx + 1).replace(/^[0-9]+_/, '').replace(/_/g, ' ').toUpperCase();
       const index = (item && item.index) ? item.index.padStart(2, '0') : String(idx + 1).padStart(2, '0');
       const media = Array.isArray(item?.media)
-        ? item.media.map(entry => normaliseMediaSource(entry)).filter(Boolean)
+        ? item.media.map(entry => safeNormaliseMediaSource(entry)).filter(Boolean)
         : [];
       let featureVideo = normaliseFeatureVideo(item?.featureVideo);
       const externalLink = typeof item?.externalLink === 'string' ? item.externalLink.trim() : '';

--- a/index.html
+++ b/index.html
@@ -558,8 +558,8 @@
     }
 
     .feature-link-placeholder {
-      width: var(--feature-video-width, min(80vw, 960px));
-      max-width: min(80vw, 960px);
+      width: 100vw;
+      max-width: 100vw;
       min-height: clamp(140px, 20vh, var(--feature-video-height));
       display: none;
       align-items: center;
@@ -581,9 +581,10 @@
     .feature-link-track {
       display: flex;
       align-items: center;
-      gap: clamp(48px, 10vw, 180px);
+      gap: clamp(8px, 3vw, 32px);
       will-change: transform;
       min-width: 100%;
+      width: 100%;
       font-family: 'Ferrite Display', sans-serif;
       font-size: clamp(36px, 7vw, 110px);
       letter-spacing: 0.16em;
@@ -594,12 +595,14 @@
       flex: 0 0 auto;
       color: var(--accent);
       text-decoration: none;
-      transition: color var(--theme-transition) ease;
+      text-transform: uppercase;
+      transition: text-shadow 0.25s ease;
     }
 
     .feature-link-item:hover,
     .feature-link-item:focus {
-      color: var(--bg-alt);
+      color: var(--accent);
+      text-shadow: 0 0 18px rgba(255, 255, 255, 0.45);
     }
 
     .feature-image-overlay {
@@ -2440,11 +2443,14 @@ document.addEventListener('DOMContentLoaded', () => {
   setTimeout(() => {
     dropSequence.forEach((idx, i) => {
       const el = icons[idx];
+      if (!el) return;
+      const restOffset = -(baseOffsets[idx] || 0);
+      el.style.setProperty('--drop-rest', `${restOffset}px`);
       el.style.animation = `dropIn 0.6s cubic-bezier(0.22,1,0.36,1) ${i * dropInterval}ms forwards`;
       el.addEventListener('animationend', () => {
         // persist final state so CSS defaults (off-screen/invisible) don't snap back
         el.style.animation = '';
-        el.style.transform = 'translateY(0)';
+        el.style.transform = `translateY(${restOffset}px)`;
         el.style.opacity   = '1';
       }, { once: true });
     });

--- a/index.html
+++ b/index.html
@@ -56,71 +56,12 @@
       visibility: hidden;
     }
 
-    #audio-debug-panel {
-      position: fixed;
-      top: 12px;
-      left: 12px;
-      padding: 10px 12px;
-      background: rgba(0, 0, 0, 0.65);
-      color: #ffffff;
-      font-family: 'Outfit', sans-serif;
-      font-size: 12px;
-      line-height: 1.4;
-      border-radius: 8px;
-      border: 1px solid rgba(255, 255, 255, 0.35);
-      z-index: 1000;
-      pointer-events: none;
-      min-width: 180px;
-      white-space: pre-line;
-      transition: background-color var(--theme-transition) ease, color var(--theme-transition) ease, border-color var(--theme-transition) ease;
-    }
-
-    body.dark-mode #audio-debug-panel {
-      background: rgba(13, 15, 20, 0.78);
-      border-color: rgba(215, 43, 43, 0.45);
-      color: #f4f4f4;
-    }
-
-    #audio-debug-panel strong {
-      display: block;
-      font-weight: 600;
-      letter-spacing: 0.05em;
-      margin-bottom: 4px;
-      text-transform: uppercase;
-    }
-
-    #audio-debug-panel ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: flex;
-      flex-direction: column;
-      gap: 2px;
-    }
-
-    #audio-debug-panel li {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 16px;
-      font-family: 'Ferrite Display', sans-serif;
-      font-size: 11px;
-      letter-spacing: 0.08em;
-    }
-
-    #audio-debug-panel .audio-debug-empty {
-      opacity: 0.7;
-      font-style: italic;
-      font-family: 'Outfit', sans-serif;
-      letter-spacing: 0.04em;
-    }
-
     /* Language toggle button styling */
     #lang-toggle {
       position: fixed;
       top: 12px;
-      left: calc(12px + 60px + 16px);
-      min-width: 0;
+      left: calc(12px + 60px + 16px + 60px + 16px);
+      width: 60px;
       height: 60px;
       display: flex;
       align-items: center;
@@ -130,11 +71,11 @@
       cursor: pointer;
       z-index: 3;
       color: var(--accent);
-      font-size: 24px;
+      font-size: 20px;
       font-weight: 700;
       transition: background var(--theme-transition) ease, color var(--theme-transition) ease, border-color var(--theme-transition) ease;
       box-sizing: border-box;
-      padding: 0 18px;
+      padding: 0;
     }
 
     iframe#topo-bg { position: fixed; top: 0; left: 0; width: 100%; height: 100%; border: none; z-index: 0; pointer-events: none; }
@@ -385,6 +326,68 @@
       background: var(--bg-main);
     }
 
+    #soundToggle {
+      position: fixed;
+      top: 12px;
+      left: calc(12px + 60px + 16px);
+      width: 60px;
+      height: 60px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      border: 4px solid var(--accent);
+      color: var(--accent);
+      background: var(--bg-main);
+      cursor: pointer;
+      z-index: 3;
+      transition: background var(--theme-transition) ease, color var(--theme-transition) ease, border-color var(--theme-transition) ease;
+      padding: 0;
+    }
+
+    #soundToggle .icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+    }
+
+    #soundToggle svg {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+
+    #soundToggle svg path,
+    #soundToggle svg line {
+      stroke: currentColor;
+      stroke-width: 1.8;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      fill: none;
+      transition: opacity 0.25s ease, transform 0.25s ease;
+    }
+
+    #soundToggle svg path.speaker {
+      fill: currentColor;
+      stroke-width: 1.2;
+    }
+
+    #soundToggle .mute-bar {
+      opacity: 0;
+      transform: scale(0.8);
+    }
+
+    #soundToggle.muted .wave {
+      opacity: 0;
+      transform: scale(0.85);
+    }
+
+    #soundToggle.muted .mute-bar {
+      opacity: 1;
+      transform: scale(1);
+    }
+
     #scrollbarTrack {
       position: fixed;
       top: 0;
@@ -543,7 +546,7 @@
       height: 100%;
       width: 100%;
       display: block;
-      object-fit: contain;
+      object-fit: cover;
     }
 
     .feature-gallery-link {
@@ -748,6 +751,17 @@
       background: transparent;
       z-index: 1;
     }
+
+    .portfolio-orbit-fade {
+      position: absolute;
+      top: 550vh;
+      left: 0;
+      width: 100vw;
+      height: clamp(120px, 18vh, 240px);
+      pointer-events: none;
+      z-index: 2;
+      background: linear-gradient(to top, var(--bg-main) 0%, transparent 100%);
+    }
     @keyframes dropIn {
       0% {
         transform: translateY(-150vh);
@@ -784,8 +798,18 @@
     document.documentElement.classList.add('i18n-loading');
   </script>
 <body>
+  <button id="modeToggle" type="button" aria-label="Toggle color mode">☾</button>
+  <button id="soundToggle" type="button" aria-label="Mute interactive audio" aria-pressed="true">
+    <span class="icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" role="presentation">
+        <path class="speaker" d="M4 9h3.6L13 5v14l-5.4-4H4z" />
+        <path class="wave" d="M16 9c1.4 1 2.2 2.6 2.2 4s-.8 3-2.2 4" />
+        <line class="mute-bar" x1="17" y1="7" x2="22" y2="17" />
+      </svg>
+    </span>
+  </button>
   <!-- Language switch button -->
-  <button id="lang-toggle">FR</button>
+  <button id="lang-toggle" type="button">FR</button>
 
   <iframe id="topo-bg" src="topo.html" scrolling="no" loading="eager" title="Topographic background"></iframe>
 
@@ -794,7 +818,6 @@
       <path d="M12 4v16m0 0-6-6m6 6 6-6" stroke="currentColor" stroke-width="3" fill="none" stroke-linecap="square" stroke-linejoin="miter"/>
     </svg>
   </div>
-  <button id="modeToggle" aria-label="Toggle color mode">☾</button>
   <div id="scrollbarTrack" aria-hidden="true"><div id="scrollbarProgress"></div></div>
 
   <!-- Contact and description -->
@@ -870,6 +893,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const orbitFrame      = document.querySelector('iframe[src="orbit_inner.html"]');
   const scrollArrow       = document.getElementById('scrollArrow');
   const modeToggle        = document.getElementById('modeToggle');
+  const soundToggle       = document.getElementById('soundToggle');
   const scrollbarProgress = document.getElementById('scrollbarProgress');
   const featureVideoShell = document.getElementById('featureVideoShell');
   const featureVideoFrame = featureVideoShell ? featureVideoShell.querySelector('.feature-video-frame') : null;
@@ -917,6 +941,16 @@ document.addEventListener('DOMContentLoaded', () => {
     folderBed: 'folder_constant.wav'
   };
 
+  const SOUND_COOLDOWNS = {
+    [SOUND_FILES.click]: 500,
+    [SOUND_FILES.interactiveText]: 450,
+    [SOUND_FILES.contactHover]: 450,
+    [SOUND_FILES.imageClick]: 600,
+    [SOUND_FILES.folderHover]: 600,
+    [SOUND_FILES.folderClick]: 600,
+    [SOUND_FILES.scrollAuto]: 1200
+  };
+
   function createSoundController() {
     const AudioCtx = window.AudioContext || window.webkitAudioContext;
     if (!AudioCtx) {
@@ -928,6 +962,7 @@ document.addEventListener('DOMContentLoaded', () => {
         setLoopVolume() {},
         stopLoop() {},
         isLoopActive() { return false; },
+        setMasterMuted() {},
         getActiveSounds() { return []; },
         onActiveChange() { return () => {}; }
       };
@@ -1057,6 +1092,15 @@ document.addEventListener('DOMContentLoaded', () => {
       if (cooldownMs && cooldownMs > 0) {
         cooldowns.set(name, performance.now());
       }
+    }
+
+    function setMasterMuted(muted, ramp = 0.2) {
+      const duration = Math.max(0.05, typeof ramp === 'number' ? ramp : 0.2);
+      const target = muted ? 0.0001 : 1;
+      const now = ctx.currentTime;
+      master.gain.cancelScheduledValues(now);
+      master.gain.setValueAtTime(master.gain.value, now);
+      master.gain.linearRampToValueAtTime(target, now + duration);
     }
 
     function playClip(name, options = {}) {
@@ -1189,6 +1233,7 @@ document.addEventListener('DOMContentLoaded', () => {
       setLoopVolume,
       stopLoop,
       isLoopActive,
+      setMasterMuted,
       getActiveSounds: snapshotActiveSounds,
       onActiveChange(callback) {
         if (typeof callback !== 'function') {
@@ -1209,61 +1254,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const soundController = createSoundController();
   const audioSupported = Boolean(soundController && soundController.supported);
-  const audioDebugPanel = document.createElement('div');
-  audioDebugPanel.id = 'audio-debug-panel';
-  const audioDebugTitle = document.createElement('strong');
-  audioDebugTitle.textContent = 'Audio Monitor';
-  const audioDebugEmpty = document.createElement('div');
-  audioDebugEmpty.className = 'audio-debug-empty';
-  const audioDebugList = document.createElement('ul');
-  audioDebugPanel.append(audioDebugTitle, audioDebugEmpty, audioDebugList);
-  document.body.appendChild(audioDebugPanel);
-
-  function updateAudioDebugPanel(sounds = []) {
-    if (!audioSupported) {
-      audioDebugEmpty.textContent = 'Audio unavailable';
-      audioDebugEmpty.style.display = 'block';
-      audioDebugList.style.display = 'none';
-      audioDebugList.innerHTML = '';
-      return;
-    }
-    const entries = Array.isArray(sounds) ? sounds.slice().sort((a, b) => a.name.localeCompare(b.name)) : [];
-    if (!entries.length) {
-      audioDebugEmpty.textContent = 'No audio active';
-      audioDebugEmpty.style.display = 'block';
-      audioDebugList.style.display = 'none';
-      audioDebugList.innerHTML = '';
-      return;
-    }
-    audioDebugEmpty.style.display = 'none';
-    audioDebugList.style.display = 'flex';
-    audioDebugList.innerHTML = '';
-    entries.forEach(sound => {
-      const item = document.createElement('li');
-      const nameSpan = document.createElement('span');
-      nameSpan.textContent = sound.name;
-      const statusSpan = document.createElement('span');
-      let statusText = sound.loop ? 'looping' : 'one-shot';
-      if (!sound.loop && sound.count && sound.count > 1) {
-        statusText += ` ×${sound.count}`;
-      }
-      if (sound.fading) {
-        statusText += ' (fading)';
-      }
-      statusSpan.textContent = statusText;
-      item.append(nameSpan, statusSpan);
-      audioDebugList.appendChild(item);
-    });
+  const SOUND_PREF_KEY = 'ms-sound-enabled';
+  let interactiveAudioEnabled = true;
+  try {
+    interactiveAudioEnabled = localStorage.getItem(SOUND_PREF_KEY) !== 'off';
+  } catch (_) {
+    interactiveAudioEnabled = true;
   }
-
-  const initialActive = typeof soundController.getActiveSounds === 'function'
-    ? soundController.getActiveSounds()
-    : [];
-  updateAudioDebugPanel(initialActive);
-  if (typeof soundController.onActiveChange === 'function') {
-    soundController.onActiveChange(updateAudioDebugPanel);
+  if (audioSupported && !interactiveAudioEnabled) {
+    soundController.setMasterMuted(true, 0.01);
   }
-
   let audioPrimed = false;
   let introPlayed = false;
   let folderZoneActive = false;
@@ -1275,10 +1275,72 @@ document.addEventListener('DOMContentLoaded', () => {
   let lastScrollY = window.scrollY || 0;
   let lastScrollTime = performance.now();
 
+  function updateSoundToggleUI() {
+    if (!soundToggle) return;
+    if (!audioSupported) {
+      soundToggle.classList.add('muted');
+      soundToggle.setAttribute('aria-pressed', 'false');
+      soundToggle.setAttribute('aria-label', 'Interactive audio unavailable');
+      soundToggle.disabled = true;
+      return;
+    }
+    soundToggle.disabled = false;
+    soundToggle.classList.toggle('muted', !interactiveAudioEnabled);
+    soundToggle.setAttribute('aria-pressed', interactiveAudioEnabled ? 'true' : 'false');
+    soundToggle.setAttribute('aria-label', interactiveAudioEnabled ? 'Mute interactive audio' : 'Unmute interactive audio');
+  }
+
+  function persistSoundPreference(enabled) {
+    try {
+      localStorage.setItem(SOUND_PREF_KEY, enabled ? 'on' : 'off');
+    } catch (_) {}
+  }
+
+  function setInteractiveAudioEnabled(enabled) {
+    if (!audioSupported) {
+      updateSoundToggleUI();
+      return;
+    }
+    const next = Boolean(enabled);
+    if (interactiveAudioEnabled === next) {
+      updateSoundToggleUI();
+      return;
+    }
+    interactiveAudioEnabled = next;
+    persistSoundPreference(next);
+    if (next) {
+      soundController.setMasterMuted(false, audioPrimed ? 0.25 : 0.1);
+      if (audioPrimed) {
+        if (folderZoneActive) {
+          soundController.ensureLoop(SOUND_FILES.folderBed, { volume: 0.22, fadeIn: 1, cooldown: 0 });
+        } else {
+          updateThemeConstant(true);
+        }
+      }
+    } else {
+      soundController.stopLoop(SOUND_FILES.scroll, 0.5);
+      soundController.stopLoop(SOUND_FILES.scrollTabs, 0.5);
+      soundController.stopLoop(SOUND_FILES.idHold, 0.5);
+      soundController.stopLoop(SOUND_FILES.folderBed, 0.5);
+      soundController.stopLoop(SOUND_FILES.lightBed, 0.5);
+      soundController.stopLoop(SOUND_FILES.darkBed, 0.5);
+      soundController.setMasterMuted(true, audioPrimed ? 0.2 : 0.01);
+    }
+    updateSoundToggleUI();
+  }
+
+  updateSoundToggleUI();
+  if (soundToggle) {
+    soundToggle.addEventListener('click', () => {
+      if (!audioSupported) return;
+      setInteractiveAudioEnabled(!interactiveAudioEnabled);
+    });
+  }
+
   function ensureSoundReady() {
-    if (!audioSupported) return;
+    if (!audioSupported || !interactiveAudioEnabled) return false;
     soundController.unlock();
-    if (audioPrimed) return;
+    if (audioPrimed) return true;
     audioPrimed = true;
     if (!introPlayed) {
       soundController.playClip(SOUND_FILES.intro, {
@@ -1298,29 +1360,41 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
       updateThemeConstant(true);
     }
+    return true;
+  }
+
+  function playEffect(name, options = {}) {
+    if (!audioSupported || !interactiveAudioEnabled) return false;
+    ensureSoundReady();
+    const finalOptions = { ...options };
+    if (finalOptions.cooldown === undefined && SOUND_COOLDOWNS[name] !== undefined) {
+      finalOptions.cooldown = SOUND_COOLDOWNS[name];
+    }
+    soundController.playClip(name, finalOptions);
+    return true;
   }
 
   function triggerInteractiveTextSound() {
-    if (!audioSupported) return;
-    ensureSoundReady();
-    soundController.playClip(SOUND_FILES.interactiveText, { volume: 0.52 });
+    playEffect(SOUND_FILES.interactiveText, { volume: 0.52 });
   }
 
   function triggerContactHoverSound() {
-    if (!audioSupported) return;
-    ensureSoundReady();
-    soundController.playClip(SOUND_FILES.contactHover, { volume: 0.58 });
+    playEffect(SOUND_FILES.contactHover, { volume: 0.58 });
   }
 
   function triggerAutoScrollSound(duration) {
-    if (!audioSupported) return;
+    if (!audioSupported || !interactiveAudioEnabled) {
+      setAutoScrollState(true, duration + 200);
+      return;
+    }
     ensureSoundReady();
-    soundController.playClip(SOUND_FILES.scrollAuto, { volume: 0.6 });
+    const cooldown = SOUND_COOLDOWNS[SOUND_FILES.scrollAuto];
+    soundController.playClip(SOUND_FILES.scrollAuto, { volume: 0.6, cooldown });
     setAutoScrollState(true, duration + 200);
   }
 
   function startIdHoldSound() {
-    if (!audioSupported) return;
+    if (!audioSupported || !interactiveAudioEnabled) return;
     ensureSoundReady();
     soundController.ensureLoop(SOUND_FILES.idHold, { volume: 0.55, fadeIn: 1, cooldown: 4000 });
   }
@@ -1351,7 +1425,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function updateThemeConstant(immediate = false) {
-    if (!audioSupported || !audioPrimed || folderZoneActive) return;
+    if (!audioSupported || !audioPrimed || folderZoneActive || !interactiveAudioEnabled) return;
     const fade = immediate ? 0.6 : 1.5;
     if (currentTheme === 'dark') {
       soundController.ensureLoop(SOUND_FILES.darkBed, { volume: 0.16, fadeIn: fade, cooldown: 0 });
@@ -1365,7 +1439,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function setFolderZoneActive(active) {
     if (folderZoneActive === active) return;
     folderZoneActive = active;
-    if (!audioSupported || !audioPrimed) return;
+    if (!audioSupported || !audioPrimed || !interactiveAudioEnabled) return;
     if (active) {
       soundController.ensureLoop(SOUND_FILES.folderBed, { volume: 0.22, fadeIn: 5, cooldown: 0 });
       soundController.stopLoop(SOUND_FILES.lightBed, 5);
@@ -1377,15 +1451,13 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function handleSoundEvent(name) {
-    if (!audioSupported) return;
+    if (!audioSupported || !interactiveAudioEnabled) return;
     switch (name) {
       case 'folder-hover':
-        ensureSoundReady();
-        soundController.playClip(SOUND_FILES.folderHover, { volume: 0.5 });
+        playEffect(SOUND_FILES.folderHover, { volume: 0.5 });
         break;
       case 'folder-click':
-        ensureSoundReady();
-        soundController.playClip(SOUND_FILES.folderClick, { volume: 0.64 });
+        playEffect(SOUND_FILES.folderClick, { volume: 0.64 });
         break;
       case 'interactive-text':
         triggerInteractiveTextSound();
@@ -1397,6 +1469,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function handleScrollAudio() {
     if (!audioSupported) return;
+    if (!interactiveAudioEnabled) {
+      soundController.stopLoop(SOUND_FILES.scroll, 0.4);
+      soundController.stopLoop(SOUND_FILES.scrollTabs, 0.4);
+      return;
+    }
     const now = performance.now();
     const currentY = window.scrollY;
     const delta = currentY - lastScrollY;
@@ -1461,7 +1538,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (event.button !== undefined && event.button !== 0) return;
     ensureSoundReady();
     if (audioSupported) {
-      soundController.playClip(SOUND_FILES.click, { volume: 0.62 });
+      playEffect(SOUND_FILES.click, { volume: 0.62 });
     }
   }, { passive: true });
 
@@ -1672,10 +1749,7 @@ document.addEventListener('DOMContentLoaded', () => {
       img.alt = `${label} preview ${baseIndex}`;
       button.appendChild(img);
       button.addEventListener('click', () => {
-        ensureSoundReady();
-        if (audioSupported) {
-          soundController.playClip(SOUND_FILES.imageClick, { volume: 0.6 });
-        }
+        playEffect(SOUND_FILES.imageClick, { volume: 0.6 });
         openImageOverlay(src);
       });
       const sizeHandler = () => adjustGalleryItemSize(button, img);
@@ -1827,11 +1901,13 @@ document.addEventListener('DOMContentLoaded', () => {
     currentFeatureVideo = selection;
     const entry = selection.entry;
     const label = entry.label || entry.index || selection.folder || 'VIDEO';
+    const folderName = typeof selection.folder === 'string' ? selection.folder.trim() : '';
     const featureVideo = entry.featureVideo;
     const hasVideo = featureVideo && typeof featureVideo.url === 'string' && featureVideo.url.trim();
     const media = Array.isArray(entry.media) ? entry.media.filter(Boolean) : [];
     const hasImages = media.length > 0;
     const externalLink = typeof entry.externalLink === 'string' ? entry.externalLink.trim() : '';
+    const preferLinkMarquee = !hasVideo && externalLink && folderName.toLowerCase() === 'web';
 
     featureVideoShell.classList.add('visible');
     if (featureVideoPlaceholder) {
@@ -1901,7 +1977,9 @@ document.addEventListener('DOMContentLoaded', () => {
       setVideoMutedState(true);
     }
 
-    if (!hasVideo && hasImages) {
+    if (preferLinkMarquee) {
+      renderFeatureLinkMarquee(externalLink);
+    } else if (!hasVideo && hasImages) {
       renderFeatureGallery(media, label);
     } else if (!hasVideo && !hasImages && externalLink) {
       renderFeatureLinkMarquee(externalLink);
@@ -2530,6 +2608,7 @@ document.addEventListener('DOMContentLoaded', () => {
   </div>
 
   <iframe src="orbit_inner.html" class="portfolio-orbit"></iframe>
+  <div class="portfolio-orbit-fade" aria-hidden="true"></div>
 
   <footer class="page-footer">
     <div class="real-footer" data-i18n="fontCredit">Ferrite Display Font by @willaggett</div>

--- a/index.html
+++ b/index.html
@@ -784,6 +784,18 @@
     }
 
   </style>
+  <script>
+    window.safeNormaliseMediaSource = function safeNormaliseMediaSource(raw) {
+      if (typeof raw !== 'string') return '';
+      const trimmed = raw.trim();
+      if (!trimmed) return '';
+      try {
+        return encodeURI(trimmed);
+      } catch (error) {
+        return trimmed;
+      }
+    };
+  </script>
 </head>
   <script>
     document.documentElement.classList.add('i18n-loading');
@@ -933,16 +945,16 @@ document.addEventListener('DOMContentLoaded', () => {
     ? (cb => window.requestIdleCallback(cb, { timeout: 2000 }))
     : (cb => setTimeout(() => cb({ didTimeout: false, timeRemaining: () => 0 }), 200));
 
-  function safeNormaliseMediaSource(raw) {
+  const safeNormaliseMediaSource = window.safeNormaliseMediaSource || (raw => {
     if (typeof raw !== 'string') return '';
     const trimmed = raw.trim();
     if (!trimmed) return '';
     try {
       return encodeURI(trimmed);
-    } catch (_) {
+    } catch (error) {
       return trimmed;
     }
-  }
+  });
 
   function shouldPreloadMedia(src) {
     if (!src) return false;

--- a/orbit_inner.html
+++ b/orbit_inner.html
@@ -382,6 +382,106 @@
       return `rgba(${r}, ${g}, ${b}, ${alpha})`;
     }
 
+    const DIRECT_VIDEO_EXT = /\.(mp4|webm|ogg)(?:\?.*)?$/i;
+    const IMAGE_EXT = /\.(?:apng|avif|gif|jpe?g|jfif|pjpe?g|pjp|png|svg|webp)$/i;
+
+    const mediaPreloadCache = new Map();
+    const mediaPreloadQueue = new Set();
+    let mediaPreloadActive = 0;
+    const MEDIA_PRELOAD_CONCURRENCY = 2;
+    const scheduleIdle = (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function')
+      ? (cb => window.requestIdleCallback(cb, { timeout: 2000 }))
+      : (cb => setTimeout(() => cb({ didTimeout: false, timeRemaining: () => 0 }), 200));
+
+    function normaliseMediaSrc(raw) {
+      if (typeof raw !== 'string') return '';
+      const trimmed = raw.trim();
+      if (!trimmed) return '';
+      try {
+        return encodeURI(trimmed);
+      } catch (_) {
+        return trimmed;
+      }
+    }
+
+    function shouldPreloadMedia(src) {
+      if (!src) return false;
+      const clean = src.split('#')[0].split('?')[0];
+      if (DIRECT_VIDEO_EXT.test(clean)) return false;
+      return IMAGE_EXT.test(clean);
+    }
+
+    function preloadMediaAsset(src) {
+      const normalised = normaliseMediaSrc(src);
+      if (!normalised || !shouldPreloadMedia(normalised)) {
+        return Promise.resolve(null);
+      }
+      if (mediaPreloadCache.has(normalised)) {
+        return mediaPreloadCache.get(normalised);
+      }
+      const promise = new Promise(resolve => {
+        const img = new Image();
+        img.decoding = 'async';
+        img.loading = 'eager';
+        const done = () => {
+          img.onload = null;
+          img.onerror = null;
+          resolve(normalised);
+        };
+        img.onload = done;
+        img.onerror = done;
+        img.src = normalised;
+      });
+      mediaPreloadCache.set(normalised, promise);
+      return promise;
+    }
+
+    function drainMediaPreloadQueue(deadline) {
+      if (!mediaPreloadQueue.size) return;
+      const timeRemaining = typeof deadline?.timeRemaining === 'function'
+        ? () => deadline.timeRemaining()
+        : () => 0;
+      while (mediaPreloadActive < MEDIA_PRELOAD_CONCURRENCY && mediaPreloadQueue.size) {
+        if (timeRemaining() <= 1 && mediaPreloadActive > 0) break;
+        const iterator = mediaPreloadQueue.values().next();
+        if (iterator.done) break;
+        const src = iterator.value;
+        mediaPreloadQueue.delete(src);
+        mediaPreloadActive++;
+        preloadMediaAsset(src).finally(() => {
+          mediaPreloadActive--;
+          scheduleIdle(drainMediaPreloadQueue);
+        });
+      }
+    }
+
+    function scheduleMediaPreload(src) {
+      const normalised = normaliseMediaSrc(src);
+      if (!normalised || !shouldPreloadMedia(normalised)) return;
+      if (mediaPreloadCache.has(normalised) || mediaPreloadQueue.has(normalised)) return;
+      mediaPreloadQueue.add(normalised);
+      scheduleIdle(drainMediaPreloadQueue);
+    }
+
+    function queueMediaPreloads(list) {
+      if (!Array.isArray(list)) return;
+      list.forEach(src => scheduleMediaPreload(src));
+    }
+
+    function queueShowcaseMediaPreload() {
+      const unique = new Set();
+      Object.values(portfolioShowcase || {}).forEach(entries => {
+        (Array.isArray(entries) ? entries : []).forEach(entry => {
+          if (!entry || !Array.isArray(entry.media)) return;
+          entry.media.forEach(src => {
+            if (!src || unique.has(src)) return;
+            unique.add(src);
+            scheduleMediaPreload(src);
+          });
+        });
+      });
+    }
+
     function cloneShowcase(map = {}) {
       const result = {};
       Object.keys(map).forEach(key => {
@@ -391,7 +491,7 @@
             const label = String(entry.label ?? '').trim() || String(entry.id ?? '').replace(/^[0-9]+_/, '').replace(/_/g, ' ');
             const index = String(entry.index ?? entry.id ?? idx + 1).split('_')[0];
             const media = Array.isArray(entry.media)
-              ? entry.media.map(src => String(src))
+              ? entry.media.map(src => normaliseMediaSrc(src)).filter(Boolean)
               : [];
             const featureVideo = sanitizeFeatureVideo(entry.featureVideo);
             const externalLink = typeof entry.externalLink === 'string' ? entry.externalLink.trim() : '';
@@ -418,6 +518,7 @@
     function setPortfolioShowcase(map) {
       const clone = cloneShowcase(map);
       portfolioShowcase = Object.keys(clone).length ? clone : cloneShowcase(DEFAULT_SHOWCASE);
+      queueShowcaseMediaPreload();
     }
 
     function getShowcaseEntries(folderName) {
@@ -429,7 +530,7 @@
         const payload = {
           index: entry.index ? String(entry.index).padStart(2, '0') : String(idx + 1).padStart(2, '0'),
           label: entry.label ? String(entry.label).toUpperCase() : '',
-          media: Array.isArray(entry.media) ? entry.media.map(src => String(src)) : [],
+          media: Array.isArray(entry.media) ? entry.media.map(src => normaliseMediaSrc(src)).filter(Boolean) : [],
           externalLink
         };
         return featureVideo ? { ...payload, featureVideo } : payload;
@@ -437,6 +538,7 @@
     }
 
     let portfolioShowcase = cloneShowcase(DEFAULT_SHOWCASE);
+    queueShowcaseMediaPreload();
     let showcaseActiveIndex = -1;
     let cardBounds = { minX: 0, maxX: window.innerWidth, minY: 0, maxY: window.innerHeight };
     function computeVisibleMetrics() {
@@ -580,7 +682,11 @@
         card.style.backgroundColor = colorWithAlpha(accentColor, 0.12);
 
         const img = document.createElement('img');
-        img.src = encodeURI(src);
+        const resolvedSrc = normaliseMediaSrc(src);
+        if (resolvedSrc) {
+          img.src = resolvedSrc;
+        }
+        img.decoding = 'async';
         img.alt = '';
         card.appendChild(img);
 
@@ -1097,10 +1203,15 @@
 
     function renderGifCards(list) {
       if (!gifPreview) return;
-      const limited = list.slice(0, 5);
+      const limited = list
+        .map(src => normaliseMediaSrc(src))
+        .filter(Boolean)
+        .slice(0, 5);
+      if (!limited.length) return;
+      queueMediaPreloads(limited);
       scheduleCardBounds();
-      limited.forEach((raw, idx) => {
-        spawnCard(raw, idx * 140 + Math.random() * 120);
+      limited.forEach((resolved, idx) => {
+        spawnCard(resolved, idx * 140 + Math.random() * 120);
       });
     }
 
@@ -1108,7 +1219,7 @@
       if (!gifPreview) return;
       clearTimeout(previewClearTimer);
       const cleaned = Array.isArray(mediaList)
-        ? mediaList.filter(src => typeof src === 'string' && src.trim())
+        ? mediaList.map(src => normaliseMediaSrc(src)).filter(Boolean)
         : [];
       if (!cleaned.length) {
         currentPreviewKey = '';
@@ -1118,6 +1229,7 @@
       const key = cleaned.join('|');
       if (key === currentPreviewKey) return;
       currentPreviewKey = key;
+      queueMediaPreloads(cleaned);
       const hadCards = gifPreview.childElementCount > 0;
       dropExistingCards({ immediate });
       const delay = immediate || !hadCards ? 0 : 220;
@@ -1367,7 +1479,10 @@
           line.appendChild(indexLabel);
           line.appendChild(word);
           line.tabIndex = 0;
-          line._entryMedia = Array.isArray(entry.media) ? entry.media.map(src => String(src)) : [];
+          line._entryMedia = Array.isArray(entry.media) ? entry.media.map(src => normaliseMediaSrc(src)).filter(Boolean) : [];
+          if (line._entryMedia.length) {
+            queueMediaPreloads(line._entryMedia);
+          }
           line._featureVideo = entry.featureVideo ? { ...entry.featureVideo } : null;
           line.addEventListener('click', () => {
             setShowcaseActive(idx);
@@ -1397,6 +1512,9 @@
           };
           const schedulePreviewWithDelay = () => {
             cancelPreviewTimer();
+            if (line._entryMedia && line._entryMedia.length) {
+              queueMediaPreloads(line._entryMedia);
+            }
             previewTimer = window.setTimeout(() => {
               previewTimer = null;
               setGifPreview(line._entryMedia);

--- a/orbit_inner.html
+++ b/orbit_inner.html
@@ -394,10 +394,12 @@
               ? entry.media.map(src => String(src))
               : [];
             const featureVideo = sanitizeFeatureVideo(entry.featureVideo);
+            const externalLink = typeof entry.externalLink === 'string' ? entry.externalLink.trim() : '';
             return {
               index: index ? index.padStart(2, '0') : String(idx + 1).padStart(2, '0'),
               label: label.toUpperCase(),
               media,
+              externalLink,
               ...(featureVideo ? { featureVideo } : {})
             };
           }
@@ -405,7 +407,8 @@
           return {
             index: String(idx + 1).padStart(2, '0'),
             label: raw.replace(/_/g, ' ').toUpperCase(),
-            media: []
+            media: [],
+            externalLink: ''
           };
         });
       });
@@ -422,10 +425,12 @@
       if (!entries || !entries.length) return [];
       return entries.map((entry, idx) => {
         const featureVideo = sanitizeFeatureVideo(entry.featureVideo);
+        const externalLink = typeof entry.externalLink === 'string' ? entry.externalLink : '';
         const payload = {
           index: entry.index ? String(entry.index).padStart(2, '0') : String(idx + 1).padStart(2, '0'),
           label: entry.label ? String(entry.label).toUpperCase() : '',
-          media: Array.isArray(entry.media) ? entry.media.map(src => String(src)) : []
+          media: Array.isArray(entry.media) ? entry.media.map(src => String(src)) : [],
+          externalLink
         };
         return featureVideo ? { ...payload, featureVideo } : payload;
       });
@@ -1348,7 +1353,8 @@
           index: entry.index,
           label: entry.label,
           media: Array.isArray(entry.media) ? entry.media.slice() : [],
-          featureVideo: entry.featureVideo ? { ...entry.featureVideo } : null
+          featureVideo: entry.featureVideo ? { ...entry.featureVideo } : null,
+          externalLink: typeof entry.externalLink === 'string' ? entry.externalLink : ''
         }));
         showcasePanel._folderName = folderName;
         entries.forEach((entry, idx) => {

--- a/orbit_inner.html
+++ b/orbit_inner.html
@@ -1382,14 +1382,28 @@
           });
           let holdTimer = null;
           let holdOrigin = null;
+          let previewTimer = null;
           const cancelHold = () => {
             if (holdTimer) {
               clearTimeout(holdTimer);
               holdTimer = null;
             }
           };
+          const cancelPreviewTimer = () => {
+            if (previewTimer) {
+              clearTimeout(previewTimer);
+              previewTimer = null;
+            }
+          };
+          const schedulePreviewWithDelay = () => {
+            cancelPreviewTimer();
+            previewTimer = window.setTimeout(() => {
+              previewTimer = null;
+              setGifPreview(line._entryMedia);
+            }, 1500);
+          };
           line.addEventListener('pointerenter', evt => {
-            setGifPreview(line._entryMedia);
+            schedulePreviewWithDelay();
             holdOrigin = { x: evt.clientX, y: evt.clientY };
             cancelHold();
             holdTimer = window.setTimeout(() => {
@@ -1401,6 +1415,7 @@
           line.addEventListener('pointerleave', () => {
             holdOrigin = null;
             cancelHold();
+            cancelPreviewTimer();
             schedulePreviewClear();
           });
           line.addEventListener('pointermove', evt => {
@@ -1418,9 +1433,11 @@
           });
           line.addEventListener('pointerdown', () => {
             cancelHold();
+            cancelPreviewTimer();
           });
           line.addEventListener('pointercancel', () => {
             cancelHold();
+            cancelPreviewTimer();
             schedulePreviewClear();
           });
           line.addEventListener('focus', () => {


### PR DESCRIPTION
## Summary
- add a dedicated interactive audio toggle and persistable mute state with cooldown-aware playback helpers
- present Web projects with a looping external link marquee while scaling gallery images to their aspect ratios
- remove the audio monitor, reposition the top controls, and add a fade overlay above the orbit iframe for a smoother transition

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbe2b6a1dc832493854209ee5c0dd8